### PR TITLE
fix iptables rule removal

### DIFF
--- a/onionshare/onionshare.py
+++ b/onionshare/onionshare.py
@@ -159,7 +159,7 @@ def tails_open_port(port):
 def tails_close_port(port):
     if get_platform() == 'Tails':
         print translated("closing_hole")
-        subprocess.call(['/sbin/iptables', '-I', 'OUTPUT', '-o', 'lo', '-p', 'tcp', '--dport', str(port), '-j', 'REJECT'])
+        subprocess.call(['/sbin/iptables', '-D', 'OUTPUT', '-o', 'lo', '-p', 'tcp', '--dport', str(port), '-j', 'ACCEPT'])
 
 def load_strings(default="en"):
     global strings


### PR DESCRIPTION
tails_close_port should remove the previously added ACCEPT rule, rather than inserting an explicit REJECT rule. This ensures the firewall is restored to its original state, which may not necessarily have had a REJECT rule on that port.
