### PR TITLE
Updated dependencies required by python-socksipy

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -14,7 +14,7 @@ cd onionshare
 Note that python-stem appears in Debian wheezy and newer (so by extension Tails 1.1 and newer), and it appears in Ubuntu 13.10 and newer. Older versions of Debian and Ubuntu aren't supported.
 
 ```sh
-sudo apt-get install -y build-essential fakeroot python-all python-stdeb python-flask python-stem python-qt4
+sudo apt-get install -y build-essential fakeroot python-all python-stdeb python-flask python-central python-socksipy python-stem python-qt4
 ./build_deb.sh
 sudo dpkg -i deb_dist/onionshare_*.deb
 ```


### PR DESCRIPTION
I took a look at the commit to use python-socksipy (commit 8666fb77d36e3de3f1827fba20e5c24573862391) and it looks like it requires a few updates to debian dependencies listed in the the BUILD.md file. This merge should fix this issue. Additionally, python-socksipy depends on python-central so I added that in as well. 
