### PR TITLE
Updated German translation

### DIFF
--- a/onionshare/strings.json
+++ b/onionshare/strings.json
@@ -202,6 +202,7 @@
 }, "de": {
     "connecting_ctrlport": "Verbinde zum Tor-Kontrollport um den versteckten Dienst auf Port {0} laufen zu lassen.",
     "cant_connect_ctrlport": "Konnte keine Verbindung zum Tor-Kontrollport auf Port {0} aufbauen. Läuft Tor?",
+    "cant_connect_socksport": "Konnte keine Verbindung zum Tor SOCKS5 Server auf Port {0} herstellen.  OnionShare setzt voraus dass Tor Browser im Hintergrund läuft. Wenn du noch ihn noch noch nicht hast kannst du ihn unter https://www.torproject.org/ herunterladen.",    
     "preparing_files": "Dateien werden vorbereitet.",
     "wait_for_hs": "Warte auf HS:",
     "wait_for_hs_trying": "Verbindungsversuch...",
@@ -218,6 +219,7 @@
     "close_on_finish": "Den Server automatisch anhalten",
     "choose_file": "Wählen Sie eine Datei",
     "closing_automatically": "Halte automatisch an, da der Download beendet wurde",
+    "large_filesize": "Warnung: Das Senden von großen Dateien kann Stunden dauern",    
     "error_tails_invalid_port": "Ungültiger Wert, Port muss eine ganze Zahl sein",
     "error_tails_unknown_root": "Unbekannter Fehler mit Tails root Prozess",
     "help_tails_port": "Nur für Tails: Port um den Firewall zu öffnen, starte Hidden Service",
@@ -236,7 +238,8 @@
     "gui_copy_url": "URL kopieren",
     "gui_downloads": "Downloads:",
     "gui_copied_url": "URL wurde in die Zwischenablage kopiert",
-    "gui_starting_server": "Bitte warten, der Server startet..."
+    "gui_starting_server": "Bitte warten, der Server startet...",
+    "gui_please_wait": "Bitte warten..."    
 },"tr": {
     "connecting_ctrlport": "{0} portundaki gizli servis kurulumu için Tor kontrol portuna bağlanıyor.",
     "cant_connect_ctrlport": "Tor kontrol {0} portuna bağlanamıyor. Tor çalışıyor mu?",


### PR DESCRIPTION
Only a few changes but to make things easier for translaters the strings.json file should be split up into separate locales. At least then one could diff the english with their locale file and find changes easier.
