### PR TITLE
Prompt for tor controller password if needed

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -40,5 +40,6 @@
     "gui_starting_server1": "Starting Tor hidden service...",
     "gui_starting_server2": "Crunching files...",
     "gui_starting_server3": "Waiting for Tor hidden service...",
-    "gui_please_wait": "Please wait..."
+    "gui_please_wait": "Please wait...",
+    "tor_control_password":"Tor control password"
 }

--- a/onionshare/onionshare.py
+++ b/onionshare/onionshare.py
@@ -109,7 +109,7 @@ class OnionShare(object):
                     authed = False
                     while not authed:
                         try:
-                            controller.authenticate(getpass('Tor control password: '))
+                            controller.authenticate(getpass('{0}: '.format(strings._('tor_control_password'))))
                             authed = True
                         except AuthenticationFailure:
                             pass


### PR DESCRIPTION
We use getpass for this (i.e. text mode).
This means that if you have password protection for your
Tor controller (advised) and you want to run onionshare-gui,
you need to do it from a terminal (so that you can enter
the password).
