### PR TITLE
Don't disable existing hidden services

### DIFF
--- a/onionshare/onionshare.py
+++ b/onionshare/onionshare.py
@@ -33,7 +33,7 @@ def hsdic2list(dic):
     return [
         pair for pairs in [
             [('HiddenServiceDir',vals[0]),('HiddenServicePort',vals[1])]
-            for vals in zip(dic['HiddenServiceDir'],dic['HiddenServicePort'])
+            for vals in zip(dic.get('HiddenServiceDir',[]),dic.get('HiddenServicePort',[]))
         ] for pair in pairs
     ]
 
@@ -41,7 +41,7 @@ class OnionShare(object):
     def __init__(self, debug=False, local_only=False, stay_open=False):
         self.port = None
         self.controller = None
-        self.original_hs = None
+        self.hidserv_dir = None
 
         # debug mode
         if debug:
@@ -59,9 +59,17 @@ class OnionShare(object):
 
     def cleanup(self):
         if self.controller:
-            if self.original_hs:
-                # This doesn't seem to remove soon-to-be-stale hs. Why???
-                self.controller.set_options(hsdic2list(self.original_hs))
+            # Get fresh hidden services (maybe changed since last time)
+            # and remove ourselves
+            hsdic = self.controller.get_conf_map('HiddenServiceOptions') or {
+                'HiddenServiceDir': [], 'HiddenServicePort': []
+            }
+            if self.hidserv_dir and self.hidserv_dir in hsdic.get('HiddenServiceDir',[]):
+                dropme = hsdic['HiddenServiceDir'].index(self.hidserv_dir)
+                del hsdic['HiddenServiceDir'][dropme]
+                del hsdic['HiddenServicePort'][dropme]
+                self.controller.set_options(hsdic2list(hsdic))
+            # Politely close the controller
             self.controller.close()
         for filename in self.cleanup_filenames:
             if os.path.isfile(filename):
@@ -104,8 +112,8 @@ class OnionShare(object):
 
             else:
                 # come up with a hidden service directory name
-                hidserv_dir = '{0}/onionshare_{1}'.format(helpers.get_tmp_dir(), helpers.random_string(8))
-                self.cleanup_filenames.append(hidserv_dir)
+                self.hidserv_dir = '{0}/onionshare_{1}'.format(helpers.get_tmp_dir(), helpers.random_string(8))
+                self.cleanup_filenames.append(self.hidserv_dir)
 
                 # connect to the tor controlport
                 self.controller = None
@@ -121,21 +129,22 @@ class OnionShare(object):
                 self.controller.authenticate()
 
                 # set up hidden service
-                self.original_hs = self.controller.get_conf_map('HiddenServiceOptions') or {
+                hsdic = self.controller.get_conf_map('HiddenServiceOptions') or {
                     'HiddenServiceDir': [], 'HiddenServicePort': []
                 }
-                new_hs = self.original_hs.copy()
-                if not hidserv_dir in new_hs['HiddenServiceDir']:
-                    # Unless another instance has opened
-                    # the same persistent_hs_dir already
-                    new_hs['HiddenServiceDir'].append(hidserv_dir)
-                    new_hs['HiddenServicePort'].append(
-                        '80 127.0.0.1:{0}'.format(self.port))
+                if self.hidserv_dir in hsdic.get('HiddenServiceDir',[]):
+                    # Maybe a stale service with the wrong local port
+                    dropme = hsdic['HiddenServiceDir'].index(self.hidserv_dir)
+                    del hsdic['HiddenServiceDir'][dropme]
+                    del hsdic['HiddenServicePort'][dropme]
+                hsdic['HiddenServiceDir'] = hsdic.get('HiddenServiceDir',[])+[self.hidserv_dir]
+                hsdic['HiddenServicePort'] = hsdic.get('HiddenServicePort',[])+[
+                    '80 127.0.0.1:{0}'.format(self.port) ]
 
-                self.controller.set_options(hsdic2list(new_hs))
+                self.controller.set_options(hsdic2list(hsdic))
 
                 # figure out the .onion hostname
-                hostname_file = '{0}/hostname'.format(hidserv_dir)
+                hostname_file = '{0}/hostname'.format(self.hidserv_dir)
                 self.onion_host = open(hostname_file, 'r').read().strip()
 
     def wait_for_hs(self):


### PR DESCRIPTION
At the moment, if tor already runs hidden services, onionshare's `set_options()` disables them.
There's also no attempt to remove onionshare's hs on `cleanup()` (although the "good news" are that even when I try, it doesn't work :wink:. I guess there's something I don't understand about controlling hs via stem).

Another minor change is that now a Ctrl-C during the `wait_for_hs()` (I do that a lot :innocent:), would also trigger `cleanup()`.
