### PR TITLE
Use controller#create_hidden_service to add new Hidden Services

### DIFF
--- a/onionshare/onionshare.py
+++ b/onionshare/onionshare.py
@@ -104,11 +104,19 @@ class OnionShare(object):
                 controller.authenticate()
 
                 # set up hidden service
-                controller.create_hidden_service(
-                    hidserv_dir,
-                    80
-                    '127.0.0.1:{0}'.format(self.port)
-                )
+                # Try to use new create_hidden_service method to not clobber
+                # existing hidden services
+                try:
+                    controller.create_hidden_service(
+                        hidserv_dir,
+                        80
+                        '127.0.0.1:{0}'.format(self.port)
+                    )
+                except AttributeError:
+                    controller.set_options([
+                        ('HiddenServiceDir', hidserv_dir),
+                        ('HiddenServicePort', '80 127.0.0.1:{0}'.format(self.port))
+                    ])
 
                 # figure out the .onion hostname
                 hostname_file = '{0}/hostname'.format(hidserv_dir)


### PR DESCRIPTION
Fixes issues where adding a new hidden service would clobber the
existing config.

Relies on the latest stem version which implements this patch. Not yet ready to merge, relies on `python-stem` debian package at least being up to date?

Fixes #87 
