### PR TITLE
Fix issue #1365

### DIFF
--- a/cli/onionshare_cli/web/web.py
+++ b/cli/onionshare_cli/web/web.py
@@ -191,7 +191,7 @@ class Web:
         self.app.static_url_path = self.static_url_path
         self.app.add_url_rule(
             self.static_url_path + "/<path:filename>",
-            endpoint="static",
+            endpoint="onionshare-static",               # This "static" line seems to raise an AssertionError, but it is not used anywhere else in the project
             view_func=self.app.send_static_file,
         )
 


### PR DESCRIPTION
By browing the code, I saw that the endpoint "static" is what causes the `AssertionError`, but that this endpoint seems not used anywhere else. So I simply changed it to "onionshare-static" and it seems to work.
Not sure if this is totally safe for now, but I ran all the tests on my computer (Artix Linux x86_64 5.10.56-1-lts) and everything was successful, I didn't even get a warning for that line.