### PR TITLE
Don't allow an upload if in non-public mode and there was no Authorization header in the request

### DIFF
--- a/cli/onionshare_cli/web/receive_mode.py
+++ b/cli/onionshare_cli/web/receive_mode.py
@@ -372,6 +372,9 @@ class ReceiveModeRequest(Request):
         if self.method == "POST":
             if self.path == "/upload" or self.path == "/upload-ajax":
                 self.upload_request = True
+                # If using a password, we should abort if there was no Authorization header sent
+                if not self.web.settings.get("general", "public") and not "Authorization" in self.headers:
+                    self.upload_request = False
 
         if self.upload_request:
             self.web.common.log("ReceiveModeRequest", "__init__")


### PR DESCRIPTION
Fixes #1396 

I am still not clear on *why* the subclassed Request middleware is triggered before the HTTPAuth's `app.before_request()` decorator is applied to the request, but in any case, this should fix the issue.

I expanded the test to not only check for the 401 response but also that an uploaded message should not exist on disk.