### PR TITLE
Fixes directory listing in send mode

### DIFF
--- a/cli/onionshare_cli/resources/templates/send.html
+++ b/cli/onionshare_cli/resources/templates/send.html
@@ -40,7 +40,7 @@
     <div class="d-flex">
       <div>
         <img width="30" height="30" title="" alt="" src="{{ static_url_path }}/img/web_folder.png" />
-        <a href="{{ info.basename }}">
+        <a href="{{ info.link }}">
           <span>{{ info.basename }}</span>
         </a>
       </div>
@@ -53,7 +53,7 @@
       <div>
         <img width="30" height="30" title="" alt="" src="{{ static_url_path }}/img/web_file.png" />
         {% if download_individual_files %}
-        <a href="{{ info.basename }}">
+        <a href="{{ info.link }}">
           <span>{{ info.basename }}</span>
         </a>
         {% else %}

--- a/cli/onionshare_cli/web/share_mode.py
+++ b/cli/onionshare_cli/web/share_mode.py
@@ -425,10 +425,7 @@ class ShareModeWeb(SendBaseModeWeb):
                 # Render directory listing
                 filenames = []
                 for filename in os.listdir(filesystem_path):
-                    if os.path.isdir(os.path.join(filesystem_path, filename)):
-                        filenames.append(filename + "/")
-                    else:
-                        filenames.append(filename)
+                    filenames.append(filename)
                 filenames.sort()
                 return self.directory_listing(filenames, path, filesystem_path)
 

--- a/desktop/tests/test_gui_share.py
+++ b/desktop/tests/test_gui_share.py
@@ -99,7 +99,7 @@ class TestShare(GuiBaseTest):
             self.assertEqual(r.status_code, 404)
             self.download_share(tab)
         else:
-            self.assertTrue('a href="test.txt"' in r.text)
+            self.assertTrue('a href="/test.txt"' in r.text)
             r = requests.get(download_file_url)
 
             tmp_file = tempfile.NamedTemporaryFile("wb", delete=False)


### PR DESCRIPTION
Fixes #1405 

Seems the changes were made in `listing.html` but send mode uses `send.html`. Just putting the basename doesn't actually work as a relative path. It's better to put the entire relative path from the base. The paths to the directory don't end with a trailing slash, hence the basename is always considered as root level by browsers. Hence providing the relative path from the root level is best and safe.