### PR TITLE
Cli installation instructions

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -57,7 +57,7 @@ Install OnionShare CLI:
 pip install --user onionshare-cli
 ```
 
-### Set path
+#### Set path
 
 When you install programs with pip and use the --user flag, it installs them into ~/.local/bin, which isn't in your path by default. To add ~/.local/bin to your path automatically for the next time you reopen the terminal or source your shell configuration file.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -59,7 +59,7 @@ pip install --user onionshare-cli
 
 #### Set path
 
-When you install programs with pip and use the --user flag, it installs them into ~/.local/bin, which isn't in your path by default. To add ~/.local/bin to your path automatically for the next time you reopen the terminal or source your shell configuration file, , do the following:
+When you install programs with pip and use the --user flag, it installs them into ~/.local/bin, which isn't in your path by default. To add ~/.local/bin to your path automatically for the next time you reopen the terminal or source your shell configuration file, do the following:
 
 First, discover what shell you are using:
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -22,13 +22,68 @@
 
 ## Installing OnionShare CLI
 
-First, make sure you have `tor` installed. In Linux, install it through your package manager. In macOS, install it with [Homebrew](https://brew.sh): `brew install tor`.
+First, make sure you have `tor` and `python3` installed. In Linux, install it through your package manager. In macOS, install it with [Homebrew](https://brew.sh): `brew install tor`. Second, OnionShare is written in python, and you can install the command line version use python's package manager `pip`.
 
-Then install OnionShare CLI:
+### Requirements
+
+Debian/Ubuntu (APT):
+```sh
+sudo apt-get install tor python3-pip
+```
+
+Arch (Pacman):
+```sh
+sudo pacman -S tor python-pip
+```
+
+CentOS, Red Hat, and Fedora (Yum):
+```sh
+sudo yum install tor python3 python3-wheel
+```
+
+macOS (Homebrew):
+```sh
+brew install tor python
+sudo easy_install pip
+```
+
+### Main
+
+#### Installation
+
+Install OnionShare CLI:
 
 ```sh
-pip install onionshare-cli
+pip install --user onionshare-cli
 ```
+
+### Set path
+
+When you install programs with pip and use the --user flag, it installs them into ~/.local/bin, which isn't in your path by default. To add ~/.local/bin to your path automatically for the next time you reopen the terminal or source your shell configuration file.
+
+Fist, discover what is your shell:
+
+```sh
+echo $SHELL
+```
+
+Then apply the path to your shell file:
+
+bash:
+
+```sh
+echo "PATH=\$PATH:~/.local/bin" >> ~/.bashrc
+source ~/.bashrc
+```
+
+zsh:
+
+```sh
+echo "PATH=\$PATH:~/.local/bin" >> ~/.zshrc
+source ~/.zshrc
+```
+
+#### Usage
 
 Then run it with:
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -59,9 +59,9 @@ pip install --user onionshare-cli
 
 #### Set path
 
-When you install programs with pip and use the --user flag, it installs them into ~/.local/bin, which isn't in your path by default. To add ~/.local/bin to your path automatically for the next time you reopen the terminal or source your shell configuration file.
+When you install programs with pip and use the --user flag, it installs them into ~/.local/bin, which isn't in your path by default. To add ~/.local/bin to your path automatically for the next time you reopen the terminal or source your shell configuration file, , do the following:
 
-Fist, discover what is your shell:
+First, discover what shell you are using:
 
 ```sh
 echo $SHELL

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -8,7 +8,7 @@ You can download OnionShare for Windows and macOS from the `OnionShare website <
 
 .. _linux:
 
-Install in Linux
+Linux
 ----------------
 
 There are various ways to install OnionShare for Linux, but the recommended way is to use either the `Flatpak <https://flatpak.org/>`_ or the `Snap <https://snapcraft.io/>`_ package.
@@ -21,6 +21,13 @@ Snap support is built-in to Ubuntu and Fedora comes with Flatpak support, but wh
 **Install OnionShare using Snap**: https://snapcraft.io/onionshare
 
 You can also download and install PGP-signed ``.flatpak`` or ``.snap`` packages from https://onionshare.org/dist/ if you prefer.
+
+.. _pip:
+
+Any OS with pip
+---------------
+
+If you want to install OnionShare just for the command line (onionshare-cli), please see the `README <https://github.com/onionshare/onionshare/blob/develop/cli/README.md>`_ in the Git repository for installation instructions with python package manager pip.
 
 .. _verifying_sigs:
 


### PR DESCRIPTION
Just so the guide contains everything.
Shoud docs.onionshare.org include this instructions or refet to them here https://docs.onionshare.org/2.3.3/en/install.html ?