### PR TITLE
Don't force mode to be sent in CLI if --persistent is in use. Store the persistent mode only the first time the persistent file is created

### DIFF
--- a/cli/onionshare_cli/__init__.py
+++ b/cli/onionshare_cli/__init__.py
@@ -201,15 +201,6 @@ def main(cwd=None):
     disable_csp = bool(args.disable_csp)
     verbose = bool(args.verbose)
 
-    if receive:
-        mode = "receive"
-    elif website:
-        mode = "website"
-    elif chat:
-        mode = "chat"
-    else:
-        mode = "share"
-
     # Verbose mode?
     common.verbose = verbose
 
@@ -223,9 +214,17 @@ def main(cwd=None):
     if persistent_filename:
         mode_settings = ModeSettings(common, persistent_filename)
         mode_settings.set("persistent", "enabled", True)
-        mode_settings.set("persistent", "mode", mode)
     else:
         mode_settings = ModeSettings(common)
+
+    if receive:
+        mode = "receive"
+    elif website:
+        mode = "website"
+    elif chat:
+        mode = "chat"
+    else:
+        mode = "share"
 
     if mode_settings.just_created:
         # This means the mode settings were just created, not loaded from disk
@@ -233,6 +232,8 @@ def main(cwd=None):
         mode_settings.set("general", "public", public)
         mode_settings.set("general", "autostart_timer", autostart_timer)
         mode_settings.set("general", "autostop_timer", autostop_timer)
+        if persistent_filename:
+            mode_settings.set("persistent", "mode", mode)
         if mode == "share":
             mode_settings.set("share", "autostop_sharing", autostop_sharing)
         if mode == "receive":


### PR DESCRIPTION
Fixes #1410 (I think)

As far as I can tell, the issue was that `--$mode` was always being assumed to be passed in.

Then if we are using persistence, we'd set that mode. But we'd still need it passed as a mode next time we used `--persistent`.

With this change, it will set the mode to the persistent file only after it's creating the file. If `--persistent` is used again next time, it'll just read the mode from that file. (Line 250, not actually shown in the diff, is what loads the mode from file if persistence was passed in and it's not a newly-created file)

For example, you can now do this:

```
onionshare-cli --public --chat --title "My Chat" --persistent ~/my-persistent-chat.json
```

Then next time, you only need to do this:

```
onionshare-cli --persistent ~/my-persistent-chat.json
```

The one catch is that you can therefore never 'override' the mode with this persistent file. But, as far as I can tell, the `--persistent` file can only be used with CLI mode, and you can only run one mode in the CLI anyway, so maybe it's not a big deal? And the advanced user can modify the mode in the settings file by hand if they want to switch the mode. 

But I think it's more realistic that for CLI, the user would have several separate persistent files - one per mode, for example - since the 'onion' attribute (its URL, keys etc) are unique per site.