### PR TITLE
Fixes typos about Linux as platform name

### DIFF
--- a/cli/tests/test_cli_common.py
+++ b/cli/tests/test_cli_common.py
@@ -169,7 +169,7 @@ class TestGetTorPaths:
             obfs4proxy_file_path,
         )
 
-    @pytest.mark.skipif(sys.platform != "Linux", reason="requires Linux")
+    @pytest.mark.skipif(sys.platform != "linux", reason="requires Linux")
     def test_get_tor_paths_linux(self, platform_linux, common_obj):
         (
             tor_path,

--- a/cli/tests/test_cli_settings.py
+++ b/cli/tests/test_cli_settings.py
@@ -123,7 +123,7 @@ class TestSettings:
             "~/Library/Application Support/OnionShare-testdata/onionshare.json"
         )
 
-    @pytest.mark.skipif(sys.platform != "Linux", reason="requires Linux")
+    @pytest.mark.skipif(sys.platform != "linux", reason="requires Linux")
     def test_filename_linux(self, monkeypatch, platform_linux):
         obj = settings.Settings(common.Common())
         assert obj.filename == os.path.expanduser(

--- a/cli/tests/test_cli_web.py
+++ b/cli/tests/test_cli_web.py
@@ -569,7 +569,7 @@ class TestRangeRequests:
             assert resp.status_code == 206
 
 
-    @pytest.mark.skipif(sys.platform != "Linux", reason="requires Linux")
+    @pytest.mark.skipif(sys.platform != "linux", reason="requires Linux")
     @check_unsupported("curl", ["--version"])
     def test_curl(self, temp_dir, tmpdir, common_obj):
         web = web_obj(temp_dir, common_obj, "share", 3)
@@ -591,7 +591,7 @@ class TestRangeRequests:
                 ]
             )
 
-    @pytest.mark.skipif(sys.platform != "Linux", reason="requires Linux")
+    @pytest.mark.skipif(sys.platform != "linux", reason="requires Linux")
     @check_unsupported("wget", ["--version"])
     def test_wget(self, temp_dir, tmpdir, common_obj):
         web = web_obj(temp_dir, common_obj, "share", 3)


### PR DESCRIPTION
It is `linux` not `Linux` in sys.platform. Now 4 more tests are running on Linux and not skipped.