### PR TITLE
Enforces light mode even if system OS is dark themed

### DIFF
--- a/desktop/src/onionshare/__init__.py
+++ b/desktop/src/onionshare/__init__.py
@@ -49,6 +49,7 @@ class Application(QtWidgets.QApplication):
         if common.platform == "Linux" or common.platform == "BSD":
             self.setAttribute(QtCore.Qt.AA_X11InitThreads, True)
         QtWidgets.QApplication.__init__(self, sys.argv)
+        self.setStyle("Fusion")
 
         # Check color mode on starting the app
         self.color_mode = self.get_color_mode(common)
@@ -56,6 +57,8 @@ class Application(QtWidgets.QApplication):
         # Enable Dark Theme
         if self.color_mode == "dark":
             self.setDarkMode()
+        else:
+            self.setLightMode()
 
         self.installEventFilter(self)
 
@@ -74,8 +77,29 @@ class Application(QtWidgets.QApplication):
             return False
         return True
 
+    def setLightMode(self):
+        light_palette = QPalette()
+        light_palette.setColor(QPalette.Window, QColor(236, 236, 236))
+        light_palette.setColor(QPalette.WindowText, Qt.black)
+        light_palette.setColor(QPalette.Base, Qt.white)
+        light_palette.setColor(QPalette.AlternateBase, QColor(245, 245, 245))
+        light_palette.setColor(QPalette.ToolTipBase, Qt.white)
+        light_palette.setColor(QPalette.ToolTipText, Qt.black)
+        light_palette.setColor(QPalette.Text, Qt.black)
+        light_palette.setColor(QPalette.Button, QColor(236, 236, 236))
+        light_palette.setColor(QPalette.ButtonText, Qt.black)
+        light_palette.setColor(QPalette.BrightText, Qt.white)
+        light_palette.setColor(QPalette.Link, QColor(0, 104, 218))
+        light_palette.setColor(QPalette.Highlight, QColor(179, 215, 255))
+        light_palette.setColor(QPalette.HighlightedText, Qt.black)
+        light_palette.setColor(QPalette.Light, Qt.white)
+        light_palette.setColor(QPalette.Midlight, QColor(245, 245, 245))
+        light_palette.setColor(QPalette.Dark, QColor(191, 191, 191))
+        light_palette.setColor(QPalette.Mid, QColor(169, 169, 169))
+        light_palette.setColor(QPalette.Shadow, Qt.black)
+        self.setPalette(light_palette)
+
     def setDarkMode(self):
-        self.setStyle("Fusion")
         dark_palette = QPalette()
         dark_palette.setColor(QPalette.Window, QColor(53, 53, 53))
         dark_palette.setColor(QPalette.WindowText, Qt.white)


### PR DESCRIPTION
Fixes #1401 

To enforce light mode if system is dark themed, and onionshare setting has light themed, at least in macOS, the default style didn't work well for enforcing and showed some dark themes anyways. So the only solution to enforce a light mode completely was to change the Fusion style. According to me, it doesn't look bad (though it of course doesn't look like default macintosh style). Attaching some screenshots for the same to give an idea of the design shift:

Fusion Screenshots:
<img width="1066" alt="Screenshot 2021-09-09 at 12 38 36 AM" src="https://user-images.githubusercontent.com/9530293/132572704-3246598a-0d80-4916-86ea-097d0e1dad40.png">
<img width="1066" alt="Screenshot 2021-09-09 at 12 39 10 AM" src="https://user-images.githubusercontent.com/9530293/132572712-091e8707-3718-4219-a44c-682630268bb5.png">

Default mac screenshots:
<img width="1066" alt="Screenshot 2021-09-09 at 12 40 14 AM" src="https://user-images.githubusercontent.com/9530293/132572762-674c3a94-c2e7-4dc4-9706-cd17e490374b.png">
<img width="1066" alt="Screenshot 2021-09-09 at 12 39 59 AM" src="https://user-images.githubusercontent.com/9530293/132572775-3d3cef81-5750-4812-82fa-c7232284aea9.png">

PS: We are already using fusion in dark mode.
