### PR TITLE
POSIX compliant input path on any shell

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -59,28 +59,13 @@ pip install --user onionshare-cli
 
 #### Set path
 
-When you install programs with pip and use the --user flag, it installs them into ~/.local/bin, which isn't in your path by default. To add ~/.local/bin to your path automatically for the next time you reopen the terminal or source your shell configuration file, do the following:
+When you install programs with pip and use the `--user` flag, it installs them into *~/.local/bin*, which isn't in your path by default. To add *~/.local/bin* to your path automatically for the next time you reopen the terminal or source your shell configuration file, do the following:
 
-First, discover what shell you are using:
-
-```sh
-echo $SHELL
-```
-
-Then apply the path to your shell file:
-
-bash:
+Apply the path to your shell file:
 
 ```sh
-echo "PATH=\$PATH:~/.local/bin" >> ~/.bashrc
-source ~/.bashrc
-```
-
-zsh:
-
-```sh
-echo "PATH=\$PATH:~/.local/bin" >> ~/.zshrc
-source ~/.zshrc
+printf "PATH=\$PATH:~/.local/bin\n" >> ~/.${SHELL##*/}rc
+source ~/.${SHELL##*/}rc
 ```
 
 #### Usage

--- a/cli/README.md
+++ b/cli/README.md
@@ -65,7 +65,7 @@ Apply the path to your shell file:
 
 ```sh
 printf "PATH=\$PATH:~/.local/bin\n" >> ~/.${SHELL##*/}rc
-source ~/.${SHELL##*/}rc
+. ~/.${SHELL##*/}rc
 ```
 
 #### Usage


### PR DESCRIPTION
`source is not posix compliant but '.' works.
Goal is less lines to read and one command that fits any shell.