### PR TITLE
Catch KeyError on unsupported locale and fall back to en properly

### DIFF
--- a/desktop/src/onionshare/strings.py
+++ b/desktop/src/onionshare/strings.py
@@ -43,9 +43,10 @@ def load_strings(common, locale_dir):
     current_locale = common.settings.get("locale")
     strings = {}
     for s in translations[default_locale]:
-        if s in translations[current_locale] and translations[current_locale][s] != "":
+        try:
             strings[s] = translations[current_locale][s]
-        else:
+        except KeyError:
+            common.log("GuiCommon", "load_strings", f"Couldn't load locale {current_locale}, falling back to {default_locale}")
             strings[s] = translations[default_locale][s]
 
 


### PR DESCRIPTION
See #1437

This fixes installs that were running a locale (set in their existing `onionshare.json` settings file) that was supported in an earlier OnionShare version, but that has been dropped in the 2.4 release as part of https://github.com/onionshare/onionshare/commit/5de48bba6e3c17b0b45516fe536a3c500fab4fc4#diff-bad479f8b6a5c87b58ab30f427dd636f1af6461b7586362e672cddf4ede39f4eR57-R92

Not sure yet if it fixes #1437 altogether, which started out as a snap issue. But I reproduced the KeyError on macOS and Linux if using a locale we don't have in 2.4.