### PR TITLE
Update weblate script to make the output more

### DIFF
--- a/docs/check-weblate.py
+++ b/docs/check-weblate.py
@@ -2,7 +2,6 @@
 import sys
 import httpx
 import asyncio
-import time
 
 
 api_token = None
@@ -63,41 +62,33 @@ async def app_percent_output(percent_min, percent_max=101):
     print("")
 
 
-async def docs_percent_output(percent_min, exclude=[]):
+async def docs_percent_output(percent_min, percent_max=101):
     out = []
     for lang_code in languages:
-        include_language = True
         percentages = []
 
         for component in docs_translations:
-            if lang_code not in docs_translations[component]:
-                include_language = False
-                break
+            if lang_code in docs_translations[component]:
+                percentages.append(docs_translations[component][lang_code])
+            else:
+                percentages.append(0)
 
-            percentages.append(docs_translations[component][lang_code])
+        average_percentage = int(sum(percentages) / len(percentages))
 
-            if docs_translations[component][lang_code] < percent_min:
-                include_language = False
-                break
+        if (
+            average_percentage != 0
+            and average_percentage >= percent_min
+            and average_percentage < percent_max
+        ):
+            out.append(f"{languages[lang_code]} ({lang_code}), {average_percentage}%")
 
-        if include_language:
-            percentages = [f"{p}%" for p in percentages]
-            percentages = ", ".join(percentages)
-            out.append(f"{languages[lang_code]} ({lang_code}), {percentages}")
-
-    excluded = []
-    for s in out:
-        if s not in exclude:
-            excluded.append(s)
-
-    excluded.sort()
+    out.sort()
 
     print(f"Docs translations >= {percent_min}%")
     print("========================")
-    print("\n".join(excluded))
+    print("\n".join(out))
 
     print("")
-    return excluded
 
 
 async def main():
@@ -140,13 +131,13 @@ async def main():
 
     print("")
 
-    # await app_percent_output(100)
     await app_percent_output(90, 101)
-    await app_percent_output(80, 90)
+    await app_percent_output(50, 90)
+    await app_percent_output(0, 50)
 
-    out100 = await docs_percent_output(100)
-    out90 = await docs_percent_output(90, out100)
-    await docs_percent_output(80, out100 + out90)
+    await docs_percent_output(90, 101)
+    await docs_percent_output(50, 90)
+    await docs_percent_output(0, 50)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Output now looks like this:

```
App translations >= 90%
=======================
Arabic (ar), 94.9%
Bengali (bn), 100.0%
Chinese (Simplified) (zh_Hans), 100.0%
Croatian (hr), 100.0%
English (en), 100.0%
Finnish (fi), 90.3%
Galician (gl), 100.0%
German (de), 100.0%
Icelandic (is), 100.0%
Japanese (ja), 100.0%
Lithuanian (lt), 100.0%
Norwegian Bokmål (nb_NO), 96.7%
Polish (pl), 100.0%
Portuguese (Brazil) (pt_BR), 100.0%
Portuguese (Portugal) (pt_PT), 100.0%
Russian (ru), 100.0%
Spanish (es), 100.0%
Swedish (sv), 100.0%
Turkish (tr), 100.0%
Ukrainian (uk), 100.0%

App translations >= 50%
=======================
Afrikaans (af), 64.0%
Catalan (ca), 82.0%
Chinese (Traditional) (zh_Hant), 83.4%
Danish (da), 88.0%
Dutch (nl), 87.0%
French (fr), 88.0%
Greek (el), 88.0%
Hindi (hi), 50.6%
Indonesian (id), 88.0%
Irish (ga), 68.2%
Italian (it), 82.9%
Kurdish (Central) (ckb), 82.9%
Persian (fa), 63.5%
Romanian (ro), 63.1%
Serbian (latin) (sr_Latn), 83.4%
Slovak (sk), 82.9%
Telugu (te), 62.2%

App translations >= 0%
=======================
Amharic (am), 1.3%
Bulgarian (bg), 44.7%
Czech (cs), 34.5%
English (Middle) (enm), 0.0%
Esperanto (eo), 13.8%
Georgian (ka), 2.3%
Gujarati (gu), 5.0%
Hebrew (he), 11.0%
Hungarian (hu), 37.3%
Khmer (Central) (km), 0.0%
Korean (ko), 9.2%
Luganda (lg), 0.0%
Macedonian (mk), 3.2%
Malay (ms), 5.9%
Punjabi (pa), 1.3%
Shona (sn), 0.0%
Sinhala (si), 0.9%
Slovenian (sl), 12.4%
Swahili (sw), 0.4%
Wolof (wo), 0.0%
Yoruba (yo), 10.1%

Docs translations >= 90%
========================
English (en), 100%
German (de), 94%
Italian (it), 95%
Norwegian Bokmål (nb_NO), 93%
Russian (ru), 100%
Spanish (es), 91%
Turkish (tr), 100%
Ukrainian (uk), 100%

Docs translations >= 50%
========================
Dutch (nl), 53%
Finnish (fi), 83%
Greek (el), 83%
Kurdish (Central) (ckb), 50%
Polish (pl), 81%
Portuguese (Brazil) (pt_BR), 81%
Portuguese (Portugal) (pt_PT), 62%

Docs translations >= 0%
========================
Arabic (ar), 33%
Bengali (bn), 15%
Catalan (ca), 23%
Chinese (Traditional) (zh_Hant), 29%
Croatian (hr), 36%
French (fr), 47%
Icelandic (is), 22%
Indonesian (id), 11%
Irish (ga), 16%
Serbian (latin) (sr_Latn), 16%
Slovak (sk), 44%
Swedish (sv), 33%
```