### PR TITLE
Correctly load a persistent Chat tab

### DIFF
--- a/desktop/src/onionshare/tab/tab.py
+++ b/desktop/src/onionshare/tab/tab.py
@@ -243,6 +243,8 @@ class Tab(QtWidgets.QWidget):
             elif mode == "website":
                 self.filenames = self.settings.get("website", "filenames")
                 self.website_mode_clicked()
+            elif mode == "chat":
+                self.chat_mode_clicked()
         else:
             # This is a new tab
             self.settings = ModeSettings(self.common)


### PR DESCRIPTION
Although we were persisting a Chat tab to disk, we weren't loading it properly at start-up - instead a pinned 'New Tab' was appearing.