### PR TITLE
Fix "KeyError: 'fr'" in desktop strings.py

### DIFF
--- a/desktop/src/onionshare/strings.py
+++ b/desktop/src/onionshare/strings.py
@@ -43,7 +43,11 @@ def load_strings(common, locale_dir):
     current_locale = common.settings.get("locale")
     strings = {}
     for s in translations[default_locale]:
-        if s in translations[current_locale] and translations[current_locale][s] != "":
+        if (
+            current_locale in translations
+            and s in translations[current_locale]
+            and translations[current_locale][s] != ""
+        ):
             strings[s] = translations[current_locale][s]
         else:
             strings[s] = translations[default_locale][s]


### PR DESCRIPTION
Before this patch, OnionShare couldn't start.

Here is the error it printed:
```
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
  File "/tmp/onionshare/desktop/src/onionshare/__main__.py", line 24, in <module>
  File "/tmp/onionshare/desktop/src/onionshare/__init__.py", line 184, in main
  File "/tmp/onionshare/desktop/src/onionshare/gui_common.py", line 67, in __init__
  File "/tmp/onionshare/desktop/src/onionshare/strings.py", line 46, in load_strings
KeyError: 'fr'
```