### PR TITLE
Fix various bugs in CLI mode and add runtime tests for it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,10 @@ jobs:
           command: |
             cd ~/repo/cli
             poetry run pytest -v ./tests
+            poetry run onionshare-cli --local-only ./tests --auto-stop-timer 2
+            poetry run onionshare-cli --local-only --receive --auto-stop-timer 2
+            poetry run onionshare-cli --local-only --website ../docs --auto-stop-timer 2
+            poetry run onionshare-cli --local-only --chat --auto-stop-timer 2
     
   test-gui:
     docker:

--- a/cli/onionshare_cli/__init__.py
+++ b/cli/onionshare_cli/__init__.py
@@ -27,8 +27,6 @@ from datetime import datetime
 from datetime import timedelta
 
 from .common import Common, CannotFindTor
-from .censorship import CensorshipCircumvention
-from .meek import Meek, MeekNotRunning
 from .web import Web
 from .onion import TorErrorProtocolError, TorTooOldEphemeral, TorTooOldStealth, Onion
 from .onionshare import OnionShare
@@ -285,20 +283,6 @@ def main(cwd=None):
     # Create the Web object
     web = Web(common, False, mode_settings, mode)
 
-    # Create the Meek object and start the meek client
-    # meek = Meek(common)
-    # meek.start()
-
-    # Create the CensorshipCircumvention object to make
-    # API calls to Tor over Meek
-    censorship = CensorshipCircumvention(common, meek)
-    # Example: request recommended bridges, pretending to be from China, using
-    # domain fronting.
-    # censorship_recommended_settings = censorship.request_settings(country="cn")
-    # print(censorship_recommended_settings)
-    # Clean up the meek subprocess once we're done working with the censorship circumvention API
-    # meek.cleanup()
-
     # Start the Onion object
     try:
         onion = Onion(common, use_tmp_dir=True)
@@ -474,9 +458,15 @@ def main(cwd=None):
             if app.autostop_timer > 0:
                 # if the auto-stop timer was set and has run out, stop the server
                 if not app.autostop_timer_thread.is_alive():
-                    if mode == "share" or (mode == "website"):
+                    if mode == "share":
                         # If there were no attempts to download the share, or all downloads are done, we can stop
                         if web.share_mode.cur_history_id == 0 or web.done:
+                            print("Stopped because auto-stop timer ran out")
+                            web.stop(app.port)
+                            break
+                    if mode == "website":
+                        # If there were no attempts to visit the website, or all downloads are done, we can stop
+                        if web.website_mode.cur_history_id == 0 or web.done:
                             print("Stopped because auto-stop timer ran out")
                             web.stop(app.port)
                             break
@@ -489,6 +479,10 @@ def main(cwd=None):
                             web.stop(app.port)
                             break
                         web.receive_mode.can_upload = False
+                    if mode == "chat":
+                        print("Stopped because auto-stop timer ran out")
+                        web.stop(app.port)
+                        break
             # Allow KeyboardInterrupt exception to be handled with threads
             # https://stackoverflow.com/questions/3788208/python-threading-ignores-keyboardinterrupt-exception
             time.sleep(0.2)

--- a/cli/onionshare_cli/__init__.py
+++ b/cli/onionshare_cli/__init__.py
@@ -464,13 +464,7 @@ def main(cwd=None):
                             print("Stopped because auto-stop timer ran out")
                             web.stop(app.port)
                             break
-                    if mode == "website":
-                        # If there were no attempts to visit the website, or all downloads are done, we can stop
-                        if web.website_mode.cur_history_id == 0 or web.done:
-                            print("Stopped because auto-stop timer ran out")
-                            web.stop(app.port)
-                            break
-                    if mode == "receive":
+                    elif mode == "receive":
                         if (
                             web.receive_mode.cur_history_id == 0
                             or not web.receive_mode.uploads_in_progress
@@ -479,7 +473,8 @@ def main(cwd=None):
                             web.stop(app.port)
                             break
                         web.receive_mode.can_upload = False
-                    if mode == "chat":
+                    else:
+                        # website or chat mode
                         print("Stopped because auto-stop timer ran out")
                         web.stop(app.port)
                         break


### PR DESCRIPTION
Fixes #1460 

Removes unnecessary censorship class invocation, which breaks CLI mode… my bad.

Fixes Website and Chat modes with auto-stop timer in CLI mode. (the former had a crash, the latter simply didn't stop on timer running out)

Adds several `poetry run onionshare-cli` tests in different modes (with an auto-stop timer so it returns), to CircleCI to catch CLI runtime bugs.