### PR TITLE
Force javascript MIME type to work around silly operating system MIME databases

### DIFF
--- a/cli/onionshare_cli/web/web.py
+++ b/cli/onionshare_cli/web/web.py
@@ -18,6 +18,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
+import mimetypes
 import os
 import queue
 import requests
@@ -79,6 +80,16 @@ class Web:
         self.common.log("Web", "__init__", f"is_gui={is_gui}, mode={mode}")
 
         self.settings = mode_settings
+
+        # Flask guesses the MIME type of files from a database on the operating
+        # system.
+        # Some operating systems, or applications that can modify the database
+        # (such as the Windows Registry) can treat .js files as text/plain,
+        # which breaks the chat app due to X-Content-Type-Options: nosniff.
+        #
+        # It's probably #notourbug but we can fix it by forcing the mimetype.
+        # https://github.com/onionshare/onionshare/issues/1443
+        mimetypes.add_type('text/javascript', '.js')
 
         # The flask app
         self.app = Flask(

--- a/desktop/tests/gui_base_test.py
+++ b/desktop/tests/gui_base_test.py
@@ -177,6 +177,13 @@ class GuiBaseTest(unittest.TestCase):
         tab.get_mode().toggle_history.click()
         self.assertEqual(tab.get_mode().history.isVisible(), not currently_visible)
 
+    def javascript_is_correct_mime_type(self, tab, file):
+        """Test that the javascript file send.js is fetchable and that its MIME type is correct"""
+        path = f"{tab.get_mode().web.static_url_path}/js/{file}"
+        url = f"http://127.0.0.1:{tab.app.port}/{path}"
+        r = requests.get(url)
+        self.assertTrue(r.headers["Content-Type"].startswith("text/javascript;"))
+
     def history_indicator(self, tab, indicator_count="1"):
         """Test that we can make sure the history is toggled off, do an action, and the indicator works"""
         # Make sure history is toggled off

--- a/desktop/tests/test_gui_chat.py
+++ b/desktop/tests/test_gui_chat.py
@@ -61,6 +61,7 @@ class TestChat(GuiBaseTest):
         tab = self.new_chat_tab()
         self.run_all_chat_mode_started_tests(tab)
         self.view_chat(tab)
+        self.javascript_is_correct_mime_type(tab, "chat.js")
         self.change_username(tab)
         self.run_all_chat_mode_stopping_tests(tab)
         self.close_all_tabs()

--- a/desktop/tests/test_gui_receive.py
+++ b/desktop/tests/test_gui_receive.py
@@ -122,6 +122,7 @@ class TestReceive(GuiBaseTest):
     def run_all_receive_mode_tests(self, tab):
         """Submit files and messages in receive mode and stop the share"""
         self.run_all_receive_mode_setup_tests(tab)
+        self.javascript_is_correct_mime_type(tab, "receive.js")
         self.upload_file(tab, self.tmpfile_test, "test.txt")
         self.history_widgets_present(tab)
         self.counter_incremented(tab, 1)

--- a/desktop/tests/test_gui_share.py
+++ b/desktop/tests/test_gui_share.py
@@ -197,6 +197,7 @@ class TestShare(GuiBaseTest):
             self.tmpfile_test
         )
         self.web_page(tab, "Total size")
+        self.javascript_is_correct_mime_type(tab, "send.js")
         self.download_share(tab)
         self.history_widgets_present(tab)
         self.server_is_stopped(tab)


### PR DESCRIPTION
Fixes #1443 (I think)

Flask relies on the OS' MIME database to guess which Content-Type header to send with the files it serves back to the browser.

In the case of Windows, the MIME database is in the Registry.

It seems that some applications might edit the Registry to change the MIME type, for at least javascript - possibly to `text/plain`. Perhaps it's an IDE that is the culprit, so that javascript files can be opened in an editor or something.

The effect is that javascript such as the Chat mode, breaks because of our X-Content-Type-Options 'nosniff' header. The browser refuses to execute the javascript as it's seen as text/plain.

People are assuming it's OnionShare's fault without realising their registry's probably been modified. It's likely OnionShare is the first time they've served an application from their own computer as a server so haven't come across the issue before.

I reproduced the issue on my Windows machine by going into RegEdit and adding a key 'Content Type' with value 'text/plain' in the `HKEY_CLASSES_ROOT` -> `.js`. 

On my Windows machine, I didn't have any such key to begin with, but when I created one and set it to text/plain, I reproduced the issue in a Chat service that was set up on my Windows OnionShare: the javascript didn't load in my macOS Tor Browser and I got Console errors about the MIME type, exactly per the above issue. So I'm pretty confident this is the cause.

Fortunately we can import `mimetypes` and force set it to `text/javascript`, and regardless of what the registry says, it works as expected after that!

See my comment in the issue for other opensource projects on Github that have found the same issue before.