### PR TITLE
Connect to the emitted TorConnectionDialog success to trigger tab update (fixes persistent tab update)

### DIFF
--- a/desktop/src/onionshare/main_window.py
+++ b/desktop/src/onionshare/main_window.py
@@ -163,6 +163,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # Start the "Connecting to Tor" dialog, which calls onion.connect()
         tor_con = TorConnectionDialog(self.common)
         tor_con.canceled.connect(self.tor_connection_canceled)
+        tor_con.success.connect(self.tabs.tor_is_connected)
         tor_con.open_tor_settings.connect(self.tor_connection_open_tor_settings)
         if not self.common.gui.local_only:
             tor_con.start()

--- a/desktop/src/onionshare/tor_connection.py
+++ b/desktop/src/onionshare/tor_connection.py
@@ -119,6 +119,7 @@ class TorConnectionDialog(QtWidgets.QProgressDialog):
         self.active = False
         # Close the dialog after connecting
         self.setValue(self.maximum())
+        self.success.emit()
 
     def _canceled_connecting_to_tor(self):
         self.common.log("TorConnectionDialog", "_canceled_connecting_to_tor")


### PR DESCRIPTION
Fixes #1493

It is probably fixed slightly differently in censorship branch, but this should do I think.