### PR TITLE
Fix individual files problem in Windows

### DIFF
--- a/cli/onionshare_cli/web/send_base_mode.py
+++ b/cli/onionshare_cli/web/send_base_mode.py
@@ -201,9 +201,6 @@ class SendBaseModeWeb:
                 self._gzip_compress(filesystem_path, gzip_filename, 6, None)
                 self.gzip_individual_files[filesystem_path] = gzip_filename
 
-                # Cleanup this temp file
-                self.web.cleanup_tempfiles.append(gzip_filename)
-
             file_to_download = self.gzip_individual_files[filesystem_path]
             filesize = os.path.getsize(self.gzip_individual_files[filesystem_path])
         else:

--- a/cli/onionshare_cli/web/web.py
+++ b/cli/onionshare_cli/web/web.py
@@ -171,7 +171,6 @@ class Web:
             self.socketio.init_app(self.app)
             self.chat_mode = ChatModeWeb(self.common, self)
 
-        self.cleanup_tempfiles = []
         self.cleanup_tempdirs = []
 
     def get_mode(self):
@@ -405,13 +404,8 @@ class Web:
         """
         self.common.log("Web", "cleanup")
 
-        # Close all of the tempfile.NamedTemporaryFile
-        for file in self.cleanup_tempfiles:
-            file.close()
-
         # Clean up the tempfile.NamedTemporaryDirectory objects
         for dir in self.cleanup_tempdirs:
             dir.cleanup()
 
-        self.cleanup_tempfiles = []
         self.cleanup_tempdirs = []

--- a/cli/tests/test_cli_web.py
+++ b/cli/tests/test_cli_web.py
@@ -50,7 +50,6 @@ def web_obj(temp_dir, common_obj, mode, num_files=0):
     web = Web(common_obj, False, mode_settings, mode)
     web.running = True
 
-    web.cleanup_tempfiles == []
     web.cleanup_tempdirs == []
     web.app.testing = True
 

--- a/cli/tests/test_cli_web.py
+++ b/cli/tests/test_cli_web.py
@@ -308,17 +308,13 @@ class TestWeb:
     def test_cleanup(self, common_obj, temp_dir_1024):
         web = web_obj(temp_dir_1024, common_obj, "share", 3)
 
-        temp_file = tempfile.NamedTemporaryFile()
         temp_dir = tempfile.TemporaryDirectory()
 
-        web.cleanup_tempfiles = [temp_file]
         web.cleanup_tempdirs = [temp_dir]
         web.cleanup()
 
-        assert os.path.exists(temp_file.name) is False
         assert os.path.exists(temp_dir.name) is False
 
-        assert web.cleanup_tempfiles == []
         assert web.cleanup_tempdirs == []
 
 


### PR DESCRIPTION
Fixes #1512.

Use a TemporaryDirectory instead of NamedTemporaryFile to avoid opening an already open file in Windows.