### PR TITLE
fix broken jinja2/markupsafe dependency chain

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -31,6 +31,7 @@ pynacl = "*"
 colorama = "*"
 gevent-websocket = "*"
 cepa = "1.8.3"
+markupsafe = "<2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"


### PR DESCRIPTION
Fix #1536