### PR TITLE
Actually compress the tarball, using tar with -z

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -65,7 +65,7 @@ git checkout $TAG
 # Delete .git, compress, and PGP sign
 cd ..
 rm -rf onionshare/.git
-tar -cf onionshare-$VERSION.tar.gz onionshare/
+tar -czf onionshare-$VERSION.tar.gz onionshare/
 
 # Move source package to dist
 cd ../..


### PR DESCRIPTION
From `tar`'s _manpage_ we have:

```
  -z, -j, -J, --lzma  Compress archive with gzip/bzip2/xz/lzma
```

Here we keep using **gzip** compression.

By doing that we shrink the size of OnionShare's tarball from its 12M to around 6.5M