### PR TITLE
Suggest the use of git shallow copy, while cloning

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -36,7 +36,7 @@ fi
 mkdir -p build/source
 mkdir -p dist
 cd build/source
-git clone https://github.com/onionshare/onionshare.git
+git clone --single-branch --branch $TAG --depth 1 https://github.com/onionshare/onionshare.git
 cd onionshare
 
 # Verify tag


### PR DESCRIPTION
By merging this one, we would follow the way of [shallow copying](https://developpaper.com/how-to-use-git-shallow-cloning-to-improve-performance/) OnionShare's repository.

This will be used only by `build-source.sh` when it clones the repository.

Once we only need to focus on a particular `tag` and its signature verification, that would save us a few seconds and bytes. That's CI/CD routines and other integrations really a friendly choice.

