### PR TITLE
More verbose and consistent Meek exception logging

### DIFF
--- a/cli/onionshare_cli/censorship.py
+++ b/cli/onionshare_cli/censorship.py
@@ -19,8 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import requests
 
-from .meek import MeekNotRunning
-
 
 class CensorshipCircumventionError(Exception):
     """
@@ -47,15 +45,12 @@ class CensorshipCircumvention(object):
         self.api_proxies = {}
         if meek:
             self.meek = meek
-            if not self.meek.meek_proxies:
-                raise MeekNotRunning()
-            else:
-                self.common.log(
-                    "CensorshipCircumvention",
-                    "__init__",
-                    "Using Meek with CensorshipCircumvention API",
-                )
-                self.api_proxies = self.meek.meek_proxies
+            self.common.log(
+                "CensorshipCircumvention",
+                "__init__",
+                "Using Meek with CensorshipCircumvention API",
+            )
+            self.api_proxies = self.meek.meek_proxies
         if onion:
             self.onion = onion
             if not self.onion.is_authenticated:

--- a/cli/onionshare_cli/meek.py
+++ b/cli/onionshare_cli/meek.py
@@ -69,7 +69,7 @@ class Meek(object):
         if self.meek_client_file_path is None or not os.path.exists(
             self.meek_client_file_path
         ):
-            raise MeekNotFound()
+            raise MeekNotFound(self.common)
 
         # Start the Meek Client as a subprocess.
         self.common.log("Meek", "start", "Starting meek client")
@@ -128,7 +128,7 @@ class Meek(object):
 
             if "CMETHOD-ERROR" in line:
                 self.cleanup()
-                raise MeekNotRunning()
+                raise MeekNotRunning(self.common, line)
                 break
 
         if self.meek_port:
@@ -137,9 +137,8 @@ class Meek(object):
                 "https": f"socks5h://{self.meek_host}:{self.meek_port}",
             }
         else:
-            self.common.log("Meek", "start", "Could not obtain the meek port")
             self.cleanup()
-            raise MeekNotRunning()
+            raise MeekNotRunning(self.common, "Could not obtain the meek port")
 
     def cleanup(self):
         """
@@ -182,8 +181,19 @@ class MeekNotRunning(Exception):
     number it started on, in order to do domain fronting.
     """
 
+    def __init__(self, common, info=None):
+        self.common = common
+        msg = "Meek experienced an error starting up"
+        if info:
+            msg = msg + f": {info}"
+        self.common.log("MeekNotRunning", "__init__", msg)
+
 
 class MeekNotFound(Exception):
     """
     We were unable to find the Meek Client binary.
     """
+
+    def __init__(self, common):
+        self.common = common
+        self.common.log("MeekNotFound", "__init__", "Could not find the meek binary")

--- a/desktop/onionshare/connection_tab.py
+++ b/desktop/onionshare/connection_tab.py
@@ -181,6 +181,11 @@ class AutoConnectTab(QtWidgets.QWidget):
         self.tor_con.start(self.curr_settings)
 
     def _got_no_bridges(self):
+        self.common.log(
+            "AutoConnectTab",
+            "_got_no_bridges",
+            "Could not obtain bridges, so falling back to trying built-in obfs4 bridges",
+        )
         # If we got no bridges, try connecting again using built-in obfs4 bridges
         self.curr_settings.set("bridges_type", "built-in")
         self.curr_settings.set("bridges_builtin_pt", "obfs4")

--- a/desktop/onionshare/moat_dialog.py
+++ b/desktop/onionshare/moat_dialog.py
@@ -236,14 +236,10 @@ class MoatThread(QtCore.QThread):
         # Start Meek so that we can do domain fronting
         try:
             self.meek.start()
-        except MeekNotFound:
-            self.common.log("MoatThread", "run", f"Could not find meek-client")
-            self.bridgedb_error.emit()
-            return
-        except MeekNotRunning:
-            self.common.log(
-                "MoatThread", "run", f"Ran meek-client, but there was an error"
-            )
+        except (
+            MeekNotFound,
+            MeekNotRunning,
+        ):
             self.bridgedb_error.emit()
             return
 


### PR DESCRIPTION
Works towards #1547

I concentrated on just making the logs more verbose. I don't know that we should actually throw UI alerts on MeekNotFound or MeekNotRunning because the current design is to gracefully fall back to trying built-in obfs4 bridges in those scenarios.

But we now have more clarity on what might've gone wrong. For example, move your `meek-client` binary out of the way and you'll see:

```
[Mar 22 2022 02:18:35 PM] AutoConnectTab.use_bridge_connect_clicked: Trying to automatically obtain bridges
[Mar 22 2022 02:18:35 PM] MeekNotFound.__init__: Could not find the meek binary
[Mar 22 2022 02:18:35 PM] AutoConnectTab._got_no_bridges: Could not obtain bridges, so falling back to trying built-in obfs4 bridges
```

Or, if you edit cli/onionshare_cli/meek.py and deliberately break the meek start-up parameters, e.g change:

```
         self.meek_env = {
             "TOR_PT_MANAGED_TRANSPORT_VER": "1",
             "TOR_PT_CLIENT_TRANSPORTS": "meek",
         }
```

to this:

```
         self.meek_env = {
             "TOR_PT_MANAGED_TRANSPORT_VER": "1",
             "TOR_PT_CLIENT_TRANSPORTS": "m33k",
         }
```

...you'll see:

```
[Mar 22 2022 02:18:50 PM] AutoConnectTab.use_bridge_connect_clicked: Trying to automatically obtain bridges
[Mar 22 2022 02:18:50 PM] Meek.start: Starting meek client
[Mar 22 2022 02:18:50 PM] Meek.cleanup
[Mar 22 2022 02:18:50 PM] MeekNotRunning.__init__: Meek experienced an error starting up: CMETHOD-ERROR m33k no such method

[Mar 22 2022 02:18:50 PM] AutoConnectTab._got_no_bridges: Could not obtain bridges, so falling back to trying built-in obfs4 bridges
```

We also didn't need to catch `MeekNotRunning` in `CensorshipCircumvention`'s init constructor because Meek will have already started by then, and will have itself raised that exception if it couldn't.