### PR TITLE
Updates tor browser version in get-tor scripts

### DIFF
--- a/desktop/scripts/get-tor-linux.py
+++ b/desktop/scripts/get-tor-linux.py
@@ -35,10 +35,10 @@ from bridges import UpdateTorBridges
 
 
 def main():
-    tarball_url = "https://dist.torproject.org/torbrowser/11.0.4/tor-browser-linux64-11.0.4_en-US.tar.xz"
-    tarball_filename = "tor-browser-linux64-11.0.4_en-US.tar.xz"
+    tarball_url = "https://dist.torproject.org/torbrowser/11.0.9/tor-browser-linux64-11.0.9_en-US.tar.xz"
+    tarball_filename = "tor-browser-linux64-11.0.9_en-US.tar.xz"
     expected_tarball_sha256 = (
-        "05a5fd6d633ca84c33bbd3e2f8ffca2d2fa2105032a430b07d3c0cf062d9e15f"
+        "baa5ccafb5c68f1c46f9ae983b9b0a0419f66d41e0483ba5aacb3462fa0a8032"
     )
 
     # Build paths

--- a/desktop/scripts/get-tor-osx.py
+++ b/desktop/scripts/get-tor-osx.py
@@ -36,10 +36,10 @@ from bridges import UpdateTorBridges
 
 
 def main():
-    dmg_url = "https://dist.torproject.org/torbrowser/11.0.4/TorBrowser-11.0.4-osx64_en-US.dmg"
-    dmg_filename = "TorBrowser-11.0.4-osx64_en-US.dmg"
+    dmg_url = "https://dist.torproject.org/torbrowser/11.0.9/TorBrowser-11.0.9-osx64_en-US.dmg"
+    dmg_filename = "TorBrowser-11.0.9-osx64_en-US.dmg"
     expected_dmg_sha256 = (
-        "309a67c8a82ae266756d7cf5ea00e94d9242e59d55eaff97dcd6201da3c8449c"
+        "e34629a178a92983924a5a89c7a988285d2d27f21832413a7f7e33af7871c8d6"
     )
 
     # Build paths

--- a/desktop/scripts/get-tor-windows.py
+++ b/desktop/scripts/get-tor-windows.py
@@ -35,10 +35,10 @@ from bridges import UpdateTorBridges
 
 
 def main():
-    exe_url = "https://dist.torproject.org/torbrowser/11.0.4/torbrowser-install-11.0.4_en-US.exe"
-    exe_filename = "torbrowser-install-11.0.4_en-US.exe"
+    exe_url = "https://dist.torproject.org/torbrowser/11.0.9/torbrowser-install-11.0.9_en-US.exe"
+    exe_filename = "torbrowser-install-11.0.9_en-US.exe"
     expected_exe_sha256 = (
-        "c7073f58f49a225bcf7668a5630e94f5f5e96fb7bed095feebf3bf8417bd3d07"
+        "e938433028b6ffb5d312db6268b19e419626b071f08209684c8e5b9f3d3df2bc"
     )
     # Build paths
     root_path = os.path.dirname(


### PR DESCRIPTION
The 11.0.4 path for tor browsers doesn't exist anymore and was throwing me error, so I updated to the latest one (11.0.9) in that path.