### PR TITLE
Remove meek workaround in Censorship Circumvention API's built-in bridges response

### DIFF
--- a/cli/onionshare_cli/onion.py
+++ b/cli/onionshare_cli/onion.py
@@ -954,20 +954,6 @@ class Onion(object):
                 "update_builtin_bridges",
                 f"Obtained bridges: {builtin_bridges}",
             )
-            if builtin_bridges["meek"]:
-                # Meek bridge needs to be defined as "meek_lite", not "meek",
-                # for it to work with obfs4proxy.
-                # We also refer to this bridge type as 'meek-azure' in our settings.
-                # So first, rename the key in the dict
-                builtin_bridges["meek-azure"] = builtin_bridges.pop("meek")
-                new_meek_bridges = []
-                # Now replace the values. They also need the url/front params appended
-                for item in builtin_bridges["meek-azure"]:
-                    newline = item.replace("meek", "meek_lite")
-                    new_meek_bridges.append(
-                        f"{newline} url=https://meek.azureedge.net/ front=ajax.aspnetcdn.com"
-                    )
-                builtin_bridges["meek-azure"] = new_meek_bridges
             # Save the new settings
             self.settings.set("bridges_builtin", builtin_bridges)
             self.settings.save()


### PR DESCRIPTION
TPO recently took their Censorship Circumvention API 'into production' - see the comms around https://gitlab.torproject.org/tpo/anti-censorship/bridgedb/-/issues/40025#note_2790866

As part of this, it looks like they started 'providing real bridges' in the response (even though we observed bridges returned from the service seemed to work already).

But another side-effect, was that previously, the data coming back for the built-in Meek bridges, was in an incorrect format (coming back with key `meek` instead of `meek-azure`, and not setting `meek-lite` in the connection parameters) and/or lacking necessary values (no url/front suffix), and so we put a workaround in place for that, on our side.

Now it looks like they've fixed the response to return valid meek-lite built-in bridges, and that ironically broke our code:

```
Traceback (most recent call last):
  File "/home/user/git/onionshare/desktop/onionshare/tor_connection.py", line 288, in run
    self.parent.onion.connect(self.settings, False, self._tor_status_update)
  File "/home/user/git/onionshare/cli/onionshare_cli/onion.py", line 669, in connect
    self.update_builtin_bridges()
  File "/home/user/git/onionshare/cli/onionshare_cli/onion.py", line 957, in update_builtin_bridges
    if builtin_bridges["meek"]:
KeyError: 'meek'
```

Removing our workaround so that it Just Works...

