### PR TITLE
Add shortcuts for modes and new/close tab. Set accessible string for modes on mode chooser

### DIFF
--- a/desktop/onionshare/main_window.py
+++ b/desktop/onionshare/main_window.py
@@ -119,6 +119,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 )
             )
         )
+        self.settings_button.setAccessibleName(strings._("gui_settings_window_title"))
         self.settings_button.clicked.connect(self.open_settings)
         self.settings_button.setStyleSheet(self.common.gui.css["settings_button"])
         self.status_bar.addPermanentWidget(self.settings_button)

--- a/desktop/onionshare/main_window.py
+++ b/desktop/onionshare/main_window.py
@@ -119,6 +119,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 )
             )
         )
+        sequence = QtGui.QKeySequence(QtCore.Qt.CTRL + QtCore.Qt.Key_H)
+        self.settings_button.setShortcut(sequence)
         self.settings_button.setAccessibleName(strings._("gui_settings_window_title"))
         self.settings_button.clicked.connect(self.open_settings)
         self.settings_button.setStyleSheet(self.common.gui.css["settings_button"])

--- a/desktop/onionshare/tab/tab.py
+++ b/desktop/onionshare/tab/tab.py
@@ -38,11 +38,17 @@ from ..widgets import Alert
 
 
 class NewTabButton(QtWidgets.QPushButton):
-    def __init__(self, common, image_filename, title, text):
+    def __init__(self, common, image_filename, title, text, shortcut):
         super(NewTabButton, self).__init__()
         self.common = common
 
         self.setFixedSize(280, 280)
+
+        # Keyboard shortcut, using the first letter of the mode
+        sequence = QtGui.QKeySequence(QtCore.Qt.CTRL + shortcut)
+        self.setShortcut(sequence)
+
+        self.setAccessibleName(title)
 
         # Image
         self.image_label = QtWidgets.QLabel(parent=self)
@@ -140,6 +146,7 @@ class Tab(QtWidgets.QWidget):
             "images/{}_mode_new_tab_share.png".format(self.common.gui.color_mode),
             strings._("gui_new_tab_share_button"),
             strings._("gui_main_page_share_button"),
+            QtCore.Qt.Key_S,
         )
         self.share_button.clicked.connect(self.share_mode_clicked)
 
@@ -148,6 +155,7 @@ class Tab(QtWidgets.QWidget):
             "images/{}_mode_new_tab_receive.png".format(self.common.gui.color_mode),
             strings._("gui_new_tab_receive_button"),
             strings._("gui_main_page_receive_button"),
+            QtCore.Qt.Key_R,
         )
         self.receive_button.clicked.connect(self.receive_mode_clicked)
 
@@ -156,6 +164,7 @@ class Tab(QtWidgets.QWidget):
             "images/{}_mode_new_tab_website.png".format(self.common.gui.color_mode),
             strings._("gui_new_tab_website_button"),
             strings._("gui_main_page_website_button"),
+            QtCore.Qt.Key_W,
         )
         self.website_button.clicked.connect(self.website_mode_clicked)
 
@@ -164,6 +173,7 @@ class Tab(QtWidgets.QWidget):
             "images/{}_mode_new_tab_chat.png".format(self.common.gui.color_mode),
             strings._("gui_new_tab_chat_button"),
             strings._("gui_main_page_chat_button"),
+            QtCore.Qt.Key_C,
         )
         self.chat_button.clicked.connect(self.chat_mode_clicked)
 

--- a/desktop/onionshare/tab_widget.py
+++ b/desktop/onionshare/tab_widget.py
@@ -55,6 +55,7 @@ class TabWidget(QtWidgets.QTabWidget):
 
         # Define the new tab button
         self.new_tab_button = QtWidgets.QPushButton("+", parent=self)
+        self.new_tab_button.setShortcut(QtCore.Qt.CTRL + QtCore.Qt.Key_T)
         self.new_tab_button.setFlat(True)
         self.new_tab_button.setFixedSize(40, 30)
         self.new_tab_button.clicked.connect(self.new_tab_clicked)
@@ -194,6 +195,10 @@ class TabWidget(QtWidgets.QTabWidget):
 
         index = self.addTab(tab, strings._("gui_new_tab"))
         self.setCurrentIndex(index)
+
+        sequence = QtGui.QKeySequence(QtCore.Qt.CTRL + QtCore.Qt.Key_X)
+        close_shortcut = QtWidgets.QShortcut(sequence, tab)
+        close_shortcut.activated.connect(lambda: self.close_tab(index))
 
         tab.init(mode_settings)
 

--- a/desktop/onionshare/tab_widget.py
+++ b/desktop/onionshare/tab_widget.py
@@ -249,6 +249,9 @@ class TabWidget(QtWidgets.QTabWidget):
             from_autoconnect=from_autoconnect,
         )
         settings_tab.close_this_tab.connect(self.close_settings_tab)
+        sequence = QtGui.QKeySequence(QtCore.Qt.CTRL + QtCore.Qt.Key_X)
+        close_shortcut = QtWidgets.QShortcut(sequence, settings_tab)
+        close_shortcut.activated.connect(self.close_settings_tab)
         self.tor_settings_tab = settings_tab.tor_settings_tab
         self.tor_settings_tab.tor_is_connected.connect(self.tor_is_connected)
         self.tor_settings_tab.tor_is_disconnected.connect(self.tor_is_disconnected)


### PR DESCRIPTION
May close #1558
May close #1559

There are now these keyboard shortcuts:

Ctrl T - New Tab
Ctrl X - Closes current tab

And from the main mode chooser screen:

Ctrl S - Share mode
Ctrl R - Receive mode
Ctrl W - Website mode (this is why I chose X for close tab, rather than W which is what browsers use)
Ctrl C - Chat mode

Ctrl H - Settings tab

I also set the [`setAccessibleName()`](https://doc.qt.io/qt-5/qwidget.html#accessibleName-prop) on the QPushButtons on the main screen, but I am not sure how to test it.
