### PR TITLE
Fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
 jobs:
   test-cli:
     docker:
-      - image: cimg/python:3.9-bullseye
+      - image: cimg/python:3.9
 
     working_directory: ~/repo
 
@@ -37,7 +37,7 @@ jobs:
     
   test-gui:
     docker:
-      - image: circleci/python:3.9-bullseye
+      - image: cimg/python:3.9
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,8 @@ jobs:
 
       - run:
           name: Run tests
+          environment:
+            QT_DEBUG_PLUGINS: 1
           command: |
             cd ~/repo/desktop
             xvfb-run poetry run pytest -v ./tests/test_gui_*.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,6 @@ jobs:
 
       - run:
           name: Run tests
-          environment:
-            QT_DEBUG_PLUGINS: 1
           command: |
             cd ~/repo/desktop
-            xvfb-run poetry run pytest -v ./tests/test_gui_*.py
+            QT_DEBUG_PLUGINS=1 xvfb-run poetry run pytest -v ./tests/test_gui_*.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
 jobs:
   test-cli:
     docker:
-      - image: circleci/python:3.9-bullseye
+      - image: cimg/python:3.9-bullseye
 
     working_directory: ~/repo
 


### PR DESCRIPTION
I think this might be a schrodinger fix of some sort.

I was able to turn on Qt debug logs by setting the `QT_DEBUG_PLUGINS=1` environment variable before running tests, and it should tell me more info about why it crashed. This was useful stackoverflow https://stackoverflow.com/a/56828770 though the solution doesn't actually work for us.

So now there's more debug output. And the act of trying to observe wtf is going on seems to have made it go away.

This also switches from legacy CircleCI container images to next-gen ones, as described here: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034