### PR TITLE
Fix icons and theming under Wayland

### DIFF
--- a/desktop/onionshare/__init__.py
+++ b/desktop/onionshare/__init__.py
@@ -48,8 +48,10 @@ class Application(QtWidgets.QApplication):
     def __init__(self, common):
         if common.platform == "Linux" or common.platform == "BSD":
             self.setAttribute(QtCore.Qt.AA_X11InitThreads, True)
+            self.setDesktopFileName("org.onionshare.OnionShare")
+            self.setOrganizationDomain("org.onionshare.OnionShare")
+            self.setOrganizationName("OnionShare")
         QtWidgets.QApplication.__init__(self, sys.argv)
-        self.setStyle("Fusion")
 
         # Check color mode on starting the app
         self.color_mode = self.get_color_mode(common)


### PR DESCRIPTION
Icons weren't working under my Plasma Wayland desktop because the organization name and domain plus the desktop file name are required to perform icon matching.
Also this PR makes OnionShare to respect the system theme and not override it with Fusion.
