### PR TITLE
restore the primary_action mode settings in a tab after OnionShare reconnects to Tor

### DIFF
--- a/desktop/onionshare/tab/mode/__init__.py
+++ b/desktop/onionshare/tab/mode/__init__.py
@@ -563,6 +563,7 @@ class Mode(QtWidgets.QWidget):
         """
         self.content_widget.show()
         self.tor_not_connected_widget.hide()
+        self.primary_action.show()
 
     def tor_connection_stopped(self):
         """


### PR DESCRIPTION
This should fix #1506

The modes call a `handle_tor_broke_custom()` when Tor settings get changed and Tor restarts, in the TorSettingsTab. That function involves hiding the primary action (which contains the mode settings widget). It's a bit moot to do so since the entire widget is hidden in favour of the 'tor_not_connected' widget, these days, but there still might be other scenarios where a disconnection from Tor is important to hide the primary nav.

Anyway, let's just re-show the primary_settings widget once Tor is reconnected after the TorSettingsTab closes.


To test:

1) Open a 'Receive mode' tab, but don't start the service
2) Go to the Tor Settings Tab and change the Tor connection mode (e.g enable obfs4 bridges or similar), to invoke a Tor reconnection
3) Once the Tor Settings Tab closes with reconnected Tor, check that the Receive mode's settings are still visible in the Receive Mode tab. (In current main branch, they are absent, and all that is present is the 'Start' button)