### PR TITLE
Ensure Tab timer starts once tor is connected

### DIFF
--- a/desktop/onionshare/main_window.py
+++ b/desktop/onionshare/main_window.py
@@ -244,17 +244,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 break
         self.tabs.open_settings_tab(from_autoconnect, active_tab=active_tab)
 
-    def settings_have_changed(self):
-        self.common.log("OnionShareGui", "settings_have_changed")
-
-        if self.common.gui.onion.is_authenticated():
-            self.status_bar.clearMessage()
-
-        # Tell each tab that settings have changed
-        for index in range(self.tabs.count()):
-            tab = self.tabs.widget(index)
-            tab.settings_have_changed()
-
     def bring_to_front(self):
         self.common.log("MainWindow", "bring_to_front")
         self.raise_()

--- a/desktop/onionshare/settings_tab.py
+++ b/desktop/onionshare/settings_tab.py
@@ -315,10 +315,6 @@ class SettingsTab(QtWidgets.QWidget):
 
         return settings
 
-    def settings_have_changed(self):
-        # Global settings have changed
-        self.common.log("SettingsTab", "settings_have_changed")
-
     def _update_autoupdate_timestamp(self, autoupdate_timestamp):
         self.common.log("SettingsTab", "_update_autoupdate_timestamp")
 

--- a/desktop/onionshare/tab/mode/__init__.py
+++ b/desktop/onionshare/tab/mode/__init__.py
@@ -564,6 +564,8 @@ class Mode(QtWidgets.QWidget):
         self.content_widget.show()
         self.tor_not_connected_widget.hide()
         self.primary_action.show()
+        if not self.tab.timer.isActive():
+            self.tab.timer.start(500)
 
     def tor_connection_stopped(self):
         """

--- a/desktop/onionshare/tab/mode/chat_mode/__init__.py
+++ b/desktop/onionshare/tab/mode/chat_mode/__init__.py
@@ -149,11 +149,5 @@ class ChatMode(Mode):
         """
         self.primary_action.hide()
 
-    def on_reload_settings(self):
-        """
-        We should be ok to re-enable the 'Start Receive Mode' button now.
-        """
-        self.primary_action.show()
-
     def update_primary_action(self):
         self.common.log("ChatMode", "update_primary_action")

--- a/desktop/onionshare/tab/mode/receive_mode/__init__.py
+++ b/desktop/onionshare/tab/mode/receive_mode/__init__.py
@@ -409,12 +409,6 @@ class ReceiveMode(Mode):
         self.history.in_progress_count -= 1
         self.history.update_in_progress()
 
-    def on_reload_settings(self):
-        """
-        We should be ok to re-enable the 'Start Receive Mode' button now.
-        """
-        self.primary_action.show()
-
     def reset_info_counters(self):
         """
         Set the info counters back to zero.

--- a/desktop/onionshare/tab/mode/share_mode/__init__.py
+++ b/desktop/onionshare/tab/mode/share_mode/__init__.py
@@ -362,16 +362,6 @@ class ShareMode(Mode):
             strings._("systray_share_canceled_message"),
         )
 
-    def on_reload_settings(self):
-        """
-        If there were some files listed for sharing, we should be ok to re-enable
-        the 'Start Sharing' button now.
-        """
-        if self.server_status.file_selection.get_num_files() > 0:
-            self.primary_action.show()
-            self.info_label.show()
-            self.remove_all_button.show()
-
     def update_primary_action(self):
         self.common.log("ShareMode", "update_primary_action")
 

--- a/desktop/onionshare/tab/mode/website_mode/__init__.py
+++ b/desktop/onionshare/tab/mode/website_mode/__init__.py
@@ -317,16 +317,6 @@ class WebsiteMode(Mode):
         """
         self.primary_action.hide()
 
-    def on_reload_settings(self):
-        """
-        If there were some files listed for sharing, we should be ok to re-enable
-        the 'Start Sharing' button now.
-        """
-        if self.server_status.file_selection.get_num_files() > 0:
-            self.primary_action.show()
-            self.info_label.show()
-            self.remove_all_button.show()
-
     def update_primary_action(self):
         self.common.log("WebsiteMode", "update_primary_action")
 

--- a/desktop/onionshare/tab/tab.py
+++ b/desktop/onionshare/tab/tab.py
@@ -630,20 +630,6 @@ class Tab(QtWidgets.QWidget):
         else:
             return None
 
-    def settings_have_changed(self):
-        # Global settings have changed
-        self.common.log("Tab", "settings_have_changed")
-
-        # We might've stopped the main requests timer if a Tor connection failed. If we've reloaded
-        # settings, we probably succeeded in obtaining a new connection. If so, restart the timer.
-        if not self.common.gui.local_only:
-            if self.common.gui.onion.is_authenticated():
-                mode = self.get_mode()
-                if mode:
-                    if not self.timer.isActive():
-                        self.timer.start(500)
-                    mode.on_reload_settings()
-
     def close_tab(self):
         self.common.log("Tab", "close_tab")
         if self.mode is None:

--- a/desktop/onionshare/tor_settings_tab.py
+++ b/desktop/onionshare/tor_settings_tab.py
@@ -903,7 +903,3 @@ class TorSettingsTab(QtWidgets.QWidget):
 
                 # Wait 1ms for the event loop to finish, then quit
                 QtCore.QTimer.singleShot(1, self.common.gui.qtapp.quit)
-
-    def settings_have_changed(self):
-        # Global settings have changed
-        self.common.log("TorSettingsTab", "settings_have_changed")


### PR DESCRIPTION
Fixes #1637

Since we have a `tor_connection_started()` method in the Mode object, I am just starting the Tab object's timer there. 

Accordingly, I don't think the old `settings_have_changed()` methods are actually needed anymore.

Likewise for the stuff that happened on `on_reload_settings()` doesn't seem to be needed in Share/Website mode anymore (perhaps we are already re-showing those widgets once we allow those Mode tabs to be visible again once Tor connects)

But I appreciate some testing - all you have to do is start a share, stop it, change the Tor Connection mode (enable or disable builtin obfs4 bridges for example), start the share again, and make sure that history widgets appear again next time you visit that share.