### PR TITLE
Add terminal QR code to CLI

### DIFF
--- a/cli/onionshare_cli/__init__.py
+++ b/cli/onionshare_cli/__init__.py
@@ -31,7 +31,7 @@ from .web import Web
 from .onion import TorErrorProtocolError, TorTooOldEphemeral, TorTooOldStealth, Onion
 from .onionshare import OnionShare
 from .mode_settings import ModeSettings
-
+from qrcode import QRCode
 
 def main(cwd=None):
     """
@@ -119,6 +119,13 @@ def main(cwd=None):
         default=False,
         help="Share files: Continue sharing after files have been sent (default is to stop sharing)",
     )
+    parser.add_argument(
+        "--qr",
+        action="store_true",
+        dest="qr",
+        default=False,
+        help="Display a QR code in the terminal for share links",
+    )
     # Receive args
     parser.add_argument(
         "--data-dir",
@@ -190,6 +197,7 @@ def main(cwd=None):
     autostart_timer = int(args.autostart_timer)
     autostop_timer = int(args.autostop_timer)
     autostop_sharing = not bool(args.no_autostop_sharing)
+    print_qr = bool(args.qr)
     data_dir = args.data_dir
     webhook_url = args.webhook_url
     disable_text = args.disable_text
@@ -229,6 +237,7 @@ def main(cwd=None):
         mode_settings.set("general", "public", public)
         mode_settings.set("general", "autostart_timer", autostart_timer)
         mode_settings.set("general", "autostop_timer", autostop_timer)
+        mode_settings.set("general", "qr", print_qr)
         if persistent_filename:
             mode_settings.set("persistent", "mode", mode)
         if mode == "share":
@@ -382,6 +391,10 @@ def main(cwd=None):
                         f"Give this address to your recipient, and tell them it won't be accessible until: {schedule.strftime('%I:%M:%S%p, %b %d, %y')}"
                     )
             print(url)
+            if mode_settings.get("general", "qr"):
+                qr = QRCode()
+                qr.add_data(url)
+                qr.print_ascii()
             print("")
             print("Waiting for the scheduled time before starting...")
             app.onion.cleanup(False)
@@ -465,6 +478,11 @@ def main(cwd=None):
                     print("Give this address and private key to the recipient:")
                     print(url)
                     print(f"Private key: {app.auth_string}")
+            if mode_settings.get("general", "qr"):
+                qr = QRCode()
+                qr.add_data(url)
+                qr.print_ascii()
+
         print("")
         print("Press Ctrl+C to stop the server")
 

--- a/cli/poetry.lock
+++ b/cli/poetry.lock
@@ -10,7 +10,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "bidict"
@@ -48,7 +48,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -353,7 +353,7 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-asyncio_client = ["aiohttp (>=3.4)"]
+asyncio-client = ["aiohttp (>=3.4)"]
 client = ["requests (>=2.21.0)", "websocket-client (>=0.54.0)"]
 
 [[package]]
@@ -369,8 +369,26 @@ bidict = ">=0.21.0"
 python-engineio = ">=4.3.0"
 
 [package.extras]
-asyncio_client = ["aiohttp (>=3.4)"]
+asyncio-client = ["aiohttp (>=3.4)"]
 client = ["requests (>=2.21.0)", "websocket-client (>=0.54.0)"]
+
+[[package]]
+name = "qrcode"
+version = "7.3.1"
+description = "QR Code image generator"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+all = ["pillow", "pytest", "pytest", "pytest-cov", "tox", "zest.releaser[recommended]"]
+dev = ["pytest", "tox"]
+maintainer = ["zest.releaser[recommended]"]
+pil = ["pillow"]
+test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "requests"
@@ -389,7 +407,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "setuptools"
@@ -514,7 +532,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "98b6df16d4977242b4669742c67ac52c85023578a418d2099bf49cd8f8520a22"
+content-hash = "cfd420df0aa7847536163352f5d87384cd016f59f00b6db586d9770db216d617"
 
 [metadata.files]
 attrs = [
@@ -862,6 +880,9 @@ python-engineio = [
 python-socketio = [
     {file = "python-socketio-5.7.1.tar.gz", hash = "sha256:5011a0cd2545c954d7df09eef7489ec424c93b001cc146599cd72f1dd20f0d46"},
     {file = "python_socketio-5.7.1-py3-none-any.whl", hash = "sha256:86ee93591c1e781d339d9a61940e62fd6cbc838390653b52a7bcc4f7ce89fe47"},
+]
+qrcode = [
+    {file = "qrcode-7.3.1.tar.gz", hash = "sha256:375a6ff240ca9bd41adc070428b5dfc1dcfbb0f2507f1ac848f6cded38956578"},
 ]
 requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -32,6 +32,7 @@ colorama = "*"
 gevent-websocket = "*"
 stem = "1.8.1"
 werkzeug = "~2.0.3"
+qrcode = "^7.3.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"


### PR DESCRIPTION
Adds option to output a QR code of the share address to the terminal in the CLI.
Uses `qrcode` python lib, added as a poetry dependency.