### PR TITLE
Include trailing '/' on directory links in file list mode.

### DIFF
--- a/cli/onionshare_cli/web/send_base_mode.py
+++ b/cli/onionshare_cli/web/send_base_mode.py
@@ -169,7 +169,7 @@ class SendBaseModeWeb:
 
             if is_dir:
                 dirs.append(
-                    {"link": os.path.join(f"/{path}", filename), "basename": filename}
+                    {"link": os.path.join(f"/{path}", filename, ""), "basename": filename}
                 )
             else:
                 size = os.path.getsize(this_filesystem_path)


### PR DESCRIPTION
This allows directory contents to properly reference included resources using relative links.

My use-case is sharing several photo-galleries, each generated using a static web-page gallery tool (`fgallery`), and each in its own directory.  I can add the entire collection and onionshare will helpfully create a directory listing for the main page.  But without the trailing `/` on the directory link, the `index.html` in each gallery is not able to locate its resources via relative references.  This patch fixes that.