### PR TITLE
Check current index tab for autoconnect

### DIFF
--- a/desktop/onionshare/tab_widget.py
+++ b/desktop/onionshare/tab_widget.py
@@ -169,8 +169,19 @@ class TabWidget(QtWidgets.QTabWidget):
             self.open_connection_tab()
 
     def check_autoconnect_tab(self):
-        if type(self.tabs[0]) is AutoConnectTab:
-            self.tabs[0].check_autoconnect()
+        tab = self.widget(self.currentIndex())
+        if not tab:
+            self.common.log(
+                "TabWidget",
+                "check_autoconnect",
+                f"tab at index {self.currentIndex()} does not exist",
+            )
+            return
+
+        tab_id = tab.tab_id
+        self.common.log("TabWidget", "check_autoconnect", f"Tab to check autoconnect: {tab_id}")
+        if type(self.tabs[tab_id]) is AutoConnectTab:
+            self.tabs[tab_id].check_autoconnect()
 
     def load_tab(self, mode_settings_id):
         # Load the tab's mode settings


### PR DESCRIPTION
Currently, we were testing the first tab for autoconnect. However, in case of persistent tabs, that doesn't work. Since autoconnect is the last tab that gets added in that case. So we need to check the current active tab.

Fixes #1651 