### PR TITLE
Fixing CI builds

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -40,5 +40,5 @@ pytest = ">=7.2.0"
 onionshare-cli = 'onionshare_cli:main'
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I have updated the pyproject.toml in cli to use poetry-core instead of poetry for build-systems.

I have also updated the code for pulling Tor Browser code. I have tried to make the code a little bit more dynamic. What I am doing right now is pulling the Tor Browser version from `https://aus1.torproject.org/torbrowser/update_3/release/downloads.json` and also the individual platform download URLs. Then using the version, I am downloading the [sha256sums file](https://dist.torproject.org/torbrowser/12.0.4/sha256sums-signed-build.txt) from the Tor Browser distribution link. This allows us to always be sure that the latest Tor Browser is downloaded. Because the distribution link becomes invalid once a new release is made.

The only thing I am a little worried is having the sha256 sum downloaded online. I am not sure how risky it is. In that case, we can probably keep the sha256sums hardcoded in the code. That will still make the CI fail, everytime a new tor browser release is made though. @micahflee @mig5 thoughts?