### PR TITLE
Changes package-ecosystem from poetry to pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "poetry"
+  - package-ecosystem: "pip"
     directory: "/docs"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Fixes https://github.com/onionshare/onionshare/pull/1683/checks?check_run_id=14032435446

The dependabot package-ecosystem doesn't have a poetry ecosystem, pip only checks the pyproject.toml file as well.