### PR TITLE
Fixes the message on warning dialog of chat closing

### DIFF
--- a/desktop/onionshare/resources/locale/en.json
+++ b/desktop/onionshare/resources/locale/en.json
@@ -203,6 +203,7 @@
     "gui_close_tab_warning_persistent_description": "Close persistent tab and lose the onion address it is using?",
     "gui_close_tab_warning_share_description": "Close tab that is sending files?",
     "gui_close_tab_warning_receive_description": "Close tab that is receiving files?",
+    "gui_close_tab_warning_chat_description": "Close tab that is hosting a chat server?",
     "gui_close_tab_warning_website_description": "Close tab that is hosting a website?",
     "gui_close_tab_warning_close": "Close",
     "gui_close_tab_warning_cancel": "Cancel",

--- a/desktop/onionshare/tab/tab.py
+++ b/desktop/onionshare/tab/tab.py
@@ -646,6 +646,8 @@ class Tab(QtWidgets.QWidget):
                     dialog_text = strings._("gui_close_tab_warning_share_description")
                 elif self.mode == self.common.gui.MODE_RECEIVE:
                     dialog_text = strings._("gui_close_tab_warning_receive_description")
+                elif self.mode == self.common.gui.MODE_CHAT:
+                    dialog_text = strings._("gui_close_tab_warning_chat_description")
                 else:
                     dialog_text = strings._("gui_close_tab_warning_website_description")
 


### PR DESCRIPTION
Currently, the message on the chat warning dialog when closing while chat server is still on shows the message of hosting a website. This PR fixes that by adding a separate message for chat mode.