### PR TITLE
Adds version information to macos

### DIFF
--- a/desktop/scripts/get-tor.py
+++ b/desktop/scripts/get-tor.py
@@ -159,7 +159,7 @@ def get_tor_macos(gpg, torkey, macos_url, macos_filename, expected_macos_sig):
         os.path.join(dist_path, "geoip6"),
     )
     shutil.copyfile(
-        os.path.join(dmg_tor_path, "MacOS", "Tor", "tor.real"),
+        os.path.join(dmg_tor_path, "MacOS", "Tor", "tor"),
         os.path.join(dist_path, "tor"),
     )
     os.chmod(os.path.join(dist_path, "tor"), 0o755)

--- a/desktop/setup-freeze.py
+++ b/desktop/setup-freeze.py
@@ -146,6 +146,10 @@ setup(
         "bdist_mac": {
             "iconfile": os.path.join("onionshare", "resources", "onionshare.icns"),
             "bundle_name": "OnionShare",
+            "plist_items": [
+                ("CFBundleShortVersionString", version),
+                ("CFBundleVersion", version),
+            ],
         },
     },
     executables=[


### PR DESCRIPTION
Fixes #1509 

I have added the info.plist informations for the version name. Also, made some updates in the get-tor method of macos to make the builds pass successfully.