### PR TITLE
Documentation update: add information about FreeBSD support

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -59,7 +59,7 @@ You can install just the command-line version of OnionShare on any operating sys
 FreeBSD
 -------
 
-Althought not being officially developed for this platform, OnionShare can also be installed on `FreeBSD <https://freebsd.org/>`_. It's available via its ports tree or as pre-built package. Should you opt to install and use OnionShare on a FreeBSD operating system, please be aware that it's **NOT** officially supported by the OnionShare project.
+Althought not being officially developed for this platform, OnionShare can also be installed on `FreeBSD <https://freebsd.org/>`_. It's available via its ports collection or as pre-built package. Should you opt to install and use OnionShare on a FreeBSD operating system, please be aware that it's **NOT** officially supported by the OnionShare project.
 
 Binary pkg Installation
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ To install the binary package, use ``pkg install pyXY-onionshare``, with ``pyXY`
 Manual port Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-To install the FreeBSD port, change directory to the `ports tree <https://freebsd.org/ports/>`_ you must have checked out before and run the following::
+To install the FreeBSD port, change directory to the `ports collection <https://freebsd.org/ports/>`_ you must have checked out before and run the following::
 
     make -s -C www/onionshare all install clean
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -68,12 +68,16 @@ To install the binary package, use ``pkg install pyXY-onionshare``, with ``pyXY`
 
     pkg install py39-onionshare
 
+For additional information and details about the FreeBSD pre-built packages, please refer to its `official Handbook section about pkg <https://docs.freebsd.org/en/books/handbook/ports/#pkgng-intro>`_.
+
 Manual port Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 To install the FreeBSD port, change directory to the `ports collection <https://freebsd.org/ports/>`_ you must have checked out before and run the following::
 
     make -s -C www/onionshare all install clean
+
+For additional information and details about the FreeBSD ports collection, please refer to its `official Handbook section about ports <https://docs.freebsd.org/en/books/handbook/ports/#ports-using>`_.
 
 .. _verifying_sigs:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -68,6 +68,13 @@ To install the binary package, use ``pkg install pyXY-onionshare``, with ``pyXY`
 
     pkg install py39-onionshare
 
+Manual port Installation
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+To install the FreeBSD port, change directory to the `ports tree <https://freebsd.org/ports/>`_ you must have checked out before and run the following::
+
+    make -s -C www/onionshare all install clean
+
 .. _verifying_sigs:
 
 Verifying PGP signatures

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -73,6 +73,8 @@ To install the binary package, use ``pkg install pyXY-onionshare``, with ``pyXY`
 
     pkg install py39-onionshare
 
+There's also a **Command-line only** version of OnionShare available as pre-built package. Replace ``py39-onionshare`` by ``py39-onionshare-cli`` if you want to install that version.
+
 For additional information and details about the FreeBSD pre-built packages, please refer to its `official Handbook section about pkg <https://docs.freebsd.org/en/books/handbook/ports/#pkgng-intro>`_.
 
 Manual port Installation
@@ -81,6 +83,8 @@ Manual port Installation
 To install the FreeBSD port, change directory to the `ports collection <https://freebsd.org/ports/>`_ you must have checked out before and run the following::
 
     make -s -C www/onionshare all install clean
+
+The ports collection also offers a dedicated port for the **Command-line only** version of OnionShare. Replace ``www/onionshare`` by ``www/onionshare-cli`` if you want to install that version.
 
 For additional information and details about the FreeBSD ports collection, please refer to its `official Handbook section about ports <https://docs.freebsd.org/en/books/handbook/ports/#ports-using>`_.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -54,6 +54,13 @@ Command-line only
 
 You can install just the command-line version of OnionShare on any operating system using the Python package manager ``pip``. :ref:`cli` has more info.
 
+.. _freebsd:
+
+FreeBSD
+-------
+
+Althought not being officially developed for this platform, OnionShare can also be installed on `FreeBSD <https://freebsd.org/>`_. It's available via its ports tree or as pre-built package. Should you opt to install and use OnionShare on a FreeBSD operating system, please be aware that it's **NOT** officially supported by the OnionShare project.
+
 .. _verifying_sigs:
 
 Verifying PGP signatures

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -61,6 +61,11 @@ FreeBSD
 
 Althought not being officially developed for this platform, OnionShare can also be installed on `FreeBSD <https://freebsd.org/>`_. It's available via its ports collection or as pre-built package. Should you opt to install and use OnionShare on a FreeBSD operating system, please be aware that it's **NOT** officially supported by the OnionShare project.
 
+Though not being offered and officially maintained by the OnionShare developers, the FreeBSD packages and ports do fetch and verifies the source codes from the official OnionShare repository (or its official release packages from `PyPI <https://pypi.org/project/onionshare-cli/>`_). Should you wish to check changes related to this platform, please refer to the following resources:
+
+- https://cgit.freebsd.org/ports/log/www/onionshare
+- https://www.freshports.org/www/onionshare
+
 Binary pkg Installation
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -66,7 +66,7 @@ Though not being offered and officially maintained by the OnionShare developers,
 - https://cgit.freebsd.org/ports/log/www/onionshare
 - https://www.freshports.org/www/onionshare
 
-Binary pkg Installation
+Manual pkg Installation
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 To install the binary package, use ``pkg install pyXY-onionshare``, with ``pyXY`` specifying the version of Python the package was built for. So, in order to install OnionShare for Python 3.9, use::

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -61,6 +61,13 @@ FreeBSD
 
 Althought not being officially developed for this platform, OnionShare can also be installed on `FreeBSD <https://freebsd.org/>`_. It's available via its ports tree or as pre-built package. Should you opt to install and use OnionShare on a FreeBSD operating system, please be aware that it's **NOT** officially supported by the OnionShare project.
 
+Binary pkg Installation
+^^^^^^^^^^^^^^^^^^^^^^^
+
+To install the binary package, use ``pkg install pyXY-onionshare``, with ``pyXY`` specifying the version of Python the package was built for. So, in order to install OnionShare for Python 3.9, use::
+
+    pkg install py39-onionshare
+
 .. _verifying_sigs:
 
 Verifying PGP signatures


### PR DESCRIPTION
by merging this request, we:

- mention that OnionShare can be installed on [FreeBSD](https://freebsd.org/);
- make clear that FreeBSD is **NOT** an official platform supported by OnionShare devs;
- link to online resources should folks wish to check/verify changes or codes;
- link to [official FreeBSD documentation](https://docs.freebsd.org/en/books/handbook/ports/) with detailed information about pkg and ports;
- document that a [cli-only](https://pypi.org/project/onionshare-cli/) version is also available for FreeBSD, either via pkg or port.

> this patch also kept in mind the preservation of the same standards as the rest of the current `install.rst` document and it aimed to use simple language (specially because it was not written by a native English speaker).

our motivation here is not only that FreeBSD has ports and packages available for OnionShare, but also that more FreeBSD-powered systems are now being used by people migrating either from Windows, Mac or any Linux-based operating system. these are also people seeking different ways to preserve their privacy :onion: 

examples of such systems, should you ask (alphabetically sorted):
- [GhostBSD](https://www.ghostbsd.org/).
- [helloSystem](https://hellosystem.github.io/docs/);
- [MidnightBSD](https://www.midnightbsd.org/);
- [NomadBSD](https://nomadbsd.org/);