### PR TITLE
Add trailing slash on directories in website mode to assist with relative asset links

### DIFF
--- a/cli/onionshare_cli/web/send_base_mode.py
+++ b/cli/onionshare_cli/web/send_base_mode.py
@@ -131,7 +131,7 @@ class SendBaseModeWeb:
 
         self.set_file_info_custom(filenames, processed_size_callback)
 
-    def directory_listing(self, filenames, path="", filesystem_path=None):
+    def directory_listing(self, filenames, path="", filesystem_path=None, add_trailing_slash=False):
         # Tell the GUI about the directory listing
         history_id = self.cur_history_id
         self.cur_history_id += 1
@@ -150,12 +150,12 @@ class SendBaseModeWeb:
         breadcrumbs_leaf = breadcrumbs.pop()[0]
 
         # If filesystem_path is None, this is the root directory listing
-        files, dirs = self.build_directory_listing(path, filenames, filesystem_path)
+        files, dirs = self.build_directory_listing(path, filenames, filesystem_path, add_trailing_slash)
         return self.directory_listing_template(
             path, files, dirs, breadcrumbs, breadcrumbs_leaf
         )
 
-    def build_directory_listing(self, path, filenames, filesystem_path):
+    def build_directory_listing(self, path, filenames, filesystem_path, add_trailing_slash=False):
         files = []
         dirs = []
 
@@ -168,9 +168,14 @@ class SendBaseModeWeb:
             is_dir = os.path.isdir(this_filesystem_path)
 
             if is_dir:
-                dirs.append(
-                    {"link": os.path.join(f"/{path}", filename), "basename": filename}
-                )
+                if add_trailing_slash:
+                    dirs.append(
+                        {"link": os.path.join(f"/{path}", filename, ""), "basename": filename}
+                    )
+                else:
+                    dirs.append(
+                        {"link": os.path.join(f"/{path}", filename), "basename": filename}
+                    )
             else:
                 size = os.path.getsize(this_filesystem_path)
                 size_human = self.common.human_readable_filesize(size)

--- a/cli/onionshare_cli/web/website_mode.py
+++ b/cli/onionshare_cli/web/website_mode.py
@@ -84,12 +84,13 @@ class WebsiteModeWeb(SendBaseModeWeb):
                     return self.stream_individual_file(self.files[index_path])
 
                 else:
-                    # Otherwise, render directory listing
+                    # Otherwise, render directory listing, and enforce trailing slash
+                    # which can help with relative asset links in sub-directories.
                     filenames = []
                     for filename in os.listdir(filesystem_path):
                         filenames.append(filename)
                     filenames.sort()
-                    return self.directory_listing(filenames, path, filesystem_path)
+                    return self.directory_listing(filenames, path, filesystem_path, True)
 
             # If it's a file
             elif os.path.isfile(filesystem_path):
@@ -112,7 +113,7 @@ class WebsiteModeWeb(SendBaseModeWeb):
                     # Root directory listing
                     filenames = list(self.root_files)
                     filenames.sort()
-                    return self.directory_listing(filenames, path)
+                    return self.directory_listing(filenames, path, None, True)
 
             else:
                 # If the path isn't found, throw a 404


### PR DESCRIPTION
This is a replacement for https://github.com/onionshare/onionshare/pull/1656

The issue is that when navigating into subdirectories in website mode, the lack of trailing slash means that a 'relative' link such as a CSS file link, is interpreted relative to the parent dir, and so doesn't load.

To test, before and after:

1) Get a static website like https://github.com/onionshare/onionshare-website . Make 2 copies of it
2) Start a Website mode share, with the two copies of the website as subdirectories
3) Go to the front page of the Website mode share and click on either of the two subdirectories

Before the fix, there is no styling because the css has been (attempted to be) loaded at the top-level dir

After the fix, the subdirectories in the top-level directory listing, have trailing slashes, and this seems to ensure the relative links work as expected.

Website and Share mode share the same code, and the fix would break the Share mode when 'navigating the tree' (the index.html is not rendered in Share mode, and for some reason, with a trailing slash in Share mode, a 404 is rendered). It's for this reason that we add a new boolean arg to be passed down to `directory_listing()` which is only `True` for Website mode (and so adds the trailing slash). Unsure if this is the most elegant fix but it seemed nicer than overriding the `directory_listing()` method entirely for Website mode.