### PR TITLE
Add missing dependencies for Fedora/CentOS

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -29,7 +29,7 @@ poetry install
 
 **Linux users:** 
 - On Debian/Debian-based distributions you may need the `libxcb-xinerama0` and `libxcb-cursor0` packages installed.
-- On Fedora/CentOS you may need the `libxcb-1.13.1-11.fc38.x86_64` and `xcb-util-0.4.1-2.fc38.x86_64` packages installed.
+- On Fedora/CentOS you may need the `libxcb-*` and `xcb-util-*` packages installed.
 
 **Windows users:** 
 - Download and install 7-Zip (x64) from https://7-zip.org/download.html. [Add](https://medium.com/@kevinmarkvi/how-to-add-executables-togit fethc-your-path-in-windows-5ffa4ce61a53) `C:\Program Files\7-Zip` to your path.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -27,7 +27,9 @@ poetry install
 
 ### Get Tor
 
-**Linux users:** You may need the `libxcb-xinerama0` and `libxcb-cursor0` packages installed.
+**Linux users:** 
+- On Debian/Debian-based distributions you may need the `libxcb-xinerama0` and `libxcb-cursor0` packages installed.
+- On Fedora/CentOS you may need the `libxcb-1.13.1-11.fc38.x86_64` and `xcb-util-0.4.1-2.fc38.x86_64` packages installed.
 
 **Windows users:** 
 - Download and install 7-Zip (x64) from https://7-zip.org/download.html. [Add](https://medium.com/@kevinmarkvi/how-to-add-executables-togit fethc-your-path-in-windows-5ffa4ce61a53) `C:\Program Files\7-Zip` to your path.


### PR DESCRIPTION
I was having trouble setting up the environment because of missing dependencies. 

Turned out being `xcb-util-0.4.1-2.fc38.x86_64` so I thought to add it in the README.

Cheers.