### PR TITLE
Update linux64 platform name and lib* names

### DIFF
--- a/desktop/scripts/get-tor.py
+++ b/desktop/scripts/get-tor.py
@@ -233,16 +233,16 @@ def get_tor_linux64(gpg, torkey, linux64_url, linux64_filename, expected_linux64
     )
     os.chmod(os.path.join(dist_path, "tor"), 0o755)
     shutil.copyfile(
-        os.path.join(tarball_tor_path, "Tor", "libcrypto.so.1.1"),
-        os.path.join(dist_path, "libcrypto.so.1.1"),
+        os.path.join(tarball_tor_path, "Tor", "libcrypto.so.3"),
+        os.path.join(dist_path, "libcrypto.so.3"),
     )
     shutil.copyfile(
         os.path.join(tarball_tor_path, "Tor", "libevent-2.1.so.7"),
         os.path.join(dist_path, "libevent-2.1.so.7"),
     )
     shutil.copyfile(
-        os.path.join(tarball_tor_path, "Tor", "libssl.so.1.1"),
-        os.path.join(dist_path, "libssl.so.1.1"),
+        os.path.join(tarball_tor_path, "Tor", "libssl.so.3"),
+        os.path.join(dist_path, "libssl.so.3"),
     )
     shutil.copyfile(
         os.path.join(tarball_tor_path, "Tor", "libstdc++", "libstdc++.so.6"),
@@ -310,7 +310,7 @@ def main(platform):
     """
     Download Tor Browser and extract tor binaries
     """
-    valid_platforms = ["win64", "macos", "linux64"]
+    valid_platforms = ["win64", "macos", "linux-x86_64"]
     if platform not in valid_platforms:
         click.echo(f"platform must be one of: {valid_platforms}")
         return
@@ -335,7 +335,7 @@ def main(platform):
         get_tor_macos(
             gpg, torkey, platform_url, platform_filename, expected_platform_sig
         )
-    elif platform == "linux64":
+    elif platform == "linux-x86_64":
         get_tor_linux64(
             gpg, torkey, platform_url, platform_filename, expected_platform_sig
         )


### PR DESCRIPTION
`get-tor.py` failed to fetch Tor for platform `linux64` because that platform is not referred in the JSON.
Also, some _lib*_ files have now different name/versions so those been updated as well.

* `linux64` renamed to `linux-x86_64`
* `libcrypto.so.1.1` renamed to `libcrypto.so.3`
* `libssl.so.1.1` renamed to `libssl.so.3`

Cheers