### PR TITLE
Raise error from waitress if not shutdown

### DIFF
--- a/cli/onionshare_cli/web/web.py
+++ b/cli/onionshare_cli/web/web.py
@@ -365,7 +365,8 @@ class Web:
                 )
                 self.waitress.run()
             except Exception as e:
-                raise WaitressException(f"Error starting Waitress: {e}")
+                if not self.waitress.shutdown:
+                    raise WaitressException(f"Error starting Waitress: {e}")
 
     def stop(self, port):
         """
@@ -398,6 +399,7 @@ class Web:
     def waitress_custom_shutdown(self):
         """Shutdown the Waitress server immediately"""
         # Code borrowed from https://github.com/Pylons/webtest/blob/4b8a3ebf984185ff4fefb31b4d0cf82682e1fcf7/webtest/http.py#L93-L104
+        self.waitress.shutdown = True
         while self.waitress._map:
             triggers = list(self.waitress._map.values())
             for trigger in triggers:


### PR DESCRIPTION
Fixes #1787

This seems to be a non-linux issue. I was unable to reproduce the error in linux, but got the error when testing in mac. In mac, when the server is stopped, for some reason (probably a thread waiting) waitress tries the creation function and raises error, which causes the modal to show. When reviewing the waitress PR, I and @mig5 had a similar [discussion](https://github.com/onionshare/onionshare/pull/1677#discussion_r1209821349). I think we might have misunderstood why the code example we followed was using the `was_shutdown` attribute. I think this might be exactly why, since in some cases the create server is called while it's getting shutdown, and in that time the error doesn't need to be raised/shown.