### PR TITLE
Remove QT_MAC_WANTS_LAYER as we are on pyside 6 now

### DIFF
--- a/desktop/onionshare/__init__.py
+++ b/desktop/onionshare/__init__.py
@@ -144,10 +144,6 @@ def main():
     common = Common()
     common.display_banner()
 
-    # Required for macOS Big Sur: https://stackoverflow.com/a/64878899
-    if common.platform == "Darwin":
-        os.environ["QT_MAC_WANTS_LAYER"] = "1"
-
     # Start the Qt app
     global qtapp
     qtapp = Application(common)


### PR DESCRIPTION
We see this warning in the console when running the UI

```
Layer-backing is always enabled. QT_MAC_WANTS_LAYER/_q_mac_wantsLayer has no effect.
```

According to https://www.loekvandenouweland.com/content/pyside2-big-sur-does-not-show-window.html, we don't need this env var any more on PySide6.