### PR TITLE
removed xdg-config access

### DIFF
--- a/flatpak/org.onionshare.OnionShare.yaml
+++ b/flatpak/org.onionshare.OnionShare.yaml
@@ -17,7 +17,6 @@ finish-args:
   - "--talk-name=org.freedesktop.Notifications"
   - "--talk-name=org.freedesktop.secrets"
   - "--filesystem=~/OnionShare:create"
-  - "--filesystem=xdg-config/onionshare:create"
 cleanup:
   - "/go"
   - "/bin/scripts"


### PR DESCRIPTION
I dont know if this is needed, but the flathub buildbot fails if this is set, at least it seem so