### PR TITLE
Adds back gnome extensions to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,7 @@ apps:
   onionshare:
     common-id: org.onionshare.OnionShare
     command: bin/onionshare
+    extensions: [gnome]
     plugs:
       - desktop
       - home


### PR DESCRIPTION
Fixes #1800 

Seems like the gnome extensions were released from the snap build in the dev release. I have added them back, and now the snap file seems to be running without crashing in my system (Fedora). I still get a lot of warning messages, but no crashing errors.

cc @micahflee @mig5 