### PR TITLE
Fix desktop/scripts/get-tor.py for linux64 platform

### DIFF
--- a/desktop/scripts/get-tor.py
+++ b/desktop/scripts/get-tor.py
@@ -24,6 +24,9 @@ working_path = os.path.join(root_path, "build", "tor")
 
 
 def get_latest_tor_version_urls(platform):
+    if platform == 'linux64':
+        platform = 'linux-x86_64'
+
     r = requests.get(torbrowser_latest_url)
     if r.status_code != 200 or platform not in r.json()["downloads"]:
         print("Tor browser latest version url not working")
@@ -233,16 +236,16 @@ def get_tor_linux64(gpg, torkey, linux64_url, linux64_filename, expected_linux64
     )
     os.chmod(os.path.join(dist_path, "tor"), 0o755)
     shutil.copyfile(
-        os.path.join(tarball_tor_path, "Tor", "libcrypto.so.1.1"),
-        os.path.join(dist_path, "libcrypto.so.1.1"),
+        os.path.join(tarball_tor_path, "Tor", "libcrypto.so.3"),
+        os.path.join(dist_path, "libcrypto.so.3"),
     )
     shutil.copyfile(
         os.path.join(tarball_tor_path, "Tor", "libevent-2.1.so.7"),
         os.path.join(dist_path, "libevent-2.1.so.7"),
     )
     shutil.copyfile(
-        os.path.join(tarball_tor_path, "Tor", "libssl.so.1.1"),
-        os.path.join(dist_path, "libssl.so.1.1"),
+        os.path.join(tarball_tor_path, "Tor", "libssl.so.3"),
+        os.path.join(dist_path, "libssl.so.3"),
     )
     shutil.copyfile(
         os.path.join(tarball_tor_path, "Tor", "libstdc++", "libstdc++.so.6"),


### PR DESCRIPTION
[`get-tor.py`](desktop/scripts/get-tor.py) doesn't currently work for the `linux64` platform. This happens for two reasons:

1. The argument `linux64` is passed directly to the `get_latest_tor_version_urls` function, which gets `downloads.json` from the TPO servers and expects to find a `linux64` keys in it. The right key, however, is `linux-x86_64`, as can be seen below (file downloaded just now).

    ```
    {
        "downloads": {
            "linux-i686": {
                "ALL": {
                    "binary": "https://dist.torproject.org/torbrowser/13.0.6/tor-browser-linux-i686-13.0.6.tar.xz",
                    "sig": "https://dist.torproject.org/torbrowser/13.0.6/tor-browser-linux-i686-13.0.6.tar.xz.asc"
                }
            },
            "linux-x86_64": {
                "ALL": {
                    "binary": "https://dist.torproject.org/torbrowser/13.0.6/tor-browser-linux-x86_64-13.0.6.tar.xz",
                    "sig": "https://dist.torproject.org/torbrowser/13.0.6/tor-browser-linux-x86_64-13.0.6.tar.xz.asc"
                }
            },
            "macos": {
                "ALL": {
                    "binary": "https://dist.torproject.org/torbrowser/13.0.6/tor-browser-macos-13.0.6.dmg",
                    "sig": "https://dist.torproject.org/torbrowser/13.0.6/tor-browser-macos-13.0.6.dmg.asc"
                }
            },
            "win32": {
                "ALL": {
                    "binary": "https://dist.torproject.org/torbrowser/13.0.6/tor-browser-windows-i686-portable-13.0.6.exe",
                    "sig": "https://dist.torproject.org/torbrowser/13.0.6/tor-browser-windows-i686-portable-13.0.6.exe.asc"
                }
            },
            "win64": {
                "ALL": {
                    "binary": "https://dist.torproject.org/torbrowser/13.0.6/tor-browser-windows-x86_64-portable-13.0.6.exe",
                    "sig": "https://dist.torproject.org/torbrowser/13.0.6/tor-browser-windows-x86_64-portable-13.0.6.exe.asc"
                }
            }
        },
        "tag": "tbb-13.0.6-build1",
        "version": "13.0.6"
    }
    ```

2. `get-tor.py` expects to find `libcrypto.so.1.1` and `libssl.so.1.1` in the Tor Browser bundle, but the latter contains the respective OpenSSL 3 versions, i.e. `libcrypto.so.3` and `libssl.so.3`.

This patch fixes both these issues without breaking the UI (i.e. you can still use `poetry run python3 scripts/get-tor.py linux64` as per the build instructions).