### PR TITLE
Adds RSA key of Saptak to verify

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -46,7 +46,7 @@ then
   echo "Tag does not verify"
   exit 1
 fi
-cat ../verify.txt | grep "using RSA key 927F419D7EC82C2F149C1BD1403C2657CD994F73"
+cat ../verify.txt | grep -e "using RSA key 927F419D7EC82C2F149C1BD1403C2657CD994F73" -e "using RSA key 2E530667425F4B93874935707B7F1772C0C6FCBF"
 if [ $? -ne 0 ]
 then
   echo "Tag signed with wrong key"


### PR DESCRIPTION
This is the equivalent key in `keys.openpgp.org`:  https://keys.openpgp.org/vks/v1/by-fingerprint/2AE3D40A6905C8E4E8ED95ECE46A2B977C14666B