### PR TITLE
Updates the git links to the pluggable transport in flatpak config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,8 +216,6 @@ jobs:
         run: |
           cd desktop
           ~/Library/Application\ Support/pypoetry/venv/bin/poetry run python ./setup-freeze.py bdist_mac
-          rm -rf build/OnionShare.app/Contents/Resources/lib
-          mv build/exe.macosx-10.9-universal2-3.11/lib build/OnionShare.app/Contents/Resources/
           ~/Library/Application\ Support/pypoetry/venv/bin/poetry run python ./scripts/build-macos.py cleanup-build
 
       - name: Compress

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Install poetry
         run: |
-          python3 -m pip install poetry
+          curl -sSL https://install.python-poetry.org | python3 -
 
       - name: Restore cache - poetry
         uses: actions/cache@v3
@@ -138,7 +138,7 @@ jobs:
       - name: Install poetry dependencies
         run: |
           cd desktop
-          /Library/Frameworks/Python.framework/Versions/3.11/bin/poetry install
+          ~/Library/Application\ Support/pypoetry/venv/bin/poetry install
 
       - name: Restore cache - tor
         uses: actions/cache@v3
@@ -149,7 +149,7 @@ jobs:
       - name: Get tor binaries from Tor Browser
         run: |
           cd desktop
-          /Library/Frameworks/Python.framework/Versions/3.11/bin/poetry run python ./scripts/get-tor.py macos
+          ~/Library/Application\ Support/pypoetry/venv/bin/poetry run python ./scripts/get-tor.py macos
 
       - name: Install Go >=1.21.1
         uses: actions/setup-go@v4
@@ -215,10 +215,10 @@ jobs:
       - name: Build OnionShare
         run: |
           cd desktop
-          /Library/Frameworks/Python.framework/Versions/3.11/bin/poetry run python ./setup-freeze.py bdist_mac
+          ~/Library/Application\ Support/pypoetry/venv/bin/poetry run python ./setup-freeze.py bdist_mac
           rm -rf build/OnionShare.app/Contents/Resources/lib
           mv build/exe.macosx-10.9-universal2-3.11/lib build/OnionShare.app/Contents/Resources/
-          /Library/Frameworks/Python.framework/Versions/3.11/bin/poetry run python ./scripts/build-macos.py cleanup-build
+          ~/Library/Application\ Support/pypoetry/venv/bin/poetry run python ./scripts/build-macos.py cleanup-build
 
       - name: Compress
         run: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -100,8 +100,8 @@ In `flatpak/org.onionshare.OnionShare.yaml`:
 
   # For each these, incorporate the output into the Flatpak manifest
   # Make sure to update the version numbers
-  ./flatpak-go-deps.py git.torproject.org/pluggable-transports/meek.git/meek-client@v0.38.0
-  ./flatpak-go-deps.py git.torproject.org/pluggable-transports/snowflake.git/client@v2.6.0
+  ./flatpak-go-deps.py gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/meek.git/meek-client@v0.38.0
+  ./flatpak-go-deps.py gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake.git/client@v2.6.0
   ./flatpak-go-deps.py gitlab.com/yawning/obfs4.git/obfs4proxy@obfs4proxy-0.0.14
   ```
   Merge the output of each of these commands into the Flatpak manifest.

--- a/desktop/scripts/build-pt-meek.ps1
+++ b/desktop/scripts/build-pt-meek.ps1
@@ -2,7 +2,7 @@ $env:MEEK_TAG = 'v0.38.0'
 
 New-Item -ItemType Directory -Force -Path .\build\meek
 cd .\build\meek
-git clone https://git.torproject.org/pluggable-transports/meek.git
+git clone https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/meek.git
 cd meek
 git checkout $MEEK_TAG
 go build .\meek-client

--- a/desktop/scripts/build-pt-meek.sh
+++ b/desktop/scripts/build-pt-meek.sh
@@ -5,7 +5,7 @@ OS=$(uname -s)
 
 mkdir -p ./build/meek
 cd ./build/meek
-git clone https://git.torproject.org/pluggable-transports/meek.git || echo "already cloned"
+git clone https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/meek.git || echo "already cloned"
 cd meek
 git checkout $MEEK_TAG
 

--- a/desktop/scripts/build-pt-snowflake.ps1
+++ b/desktop/scripts/build-pt-snowflake.ps1
@@ -2,7 +2,7 @@ $env:SNOWFLAKE_TAG = 'v2.8.1'
 
 New-Item -ItemType Directory -Force -Path .\build\snowflake
 cd .\build\snowflake
-git clone https://git.torproject.org/pluggable-transports/snowflake.git
+git clone https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake.git
 cd snowflake
 git checkout $SNOWFLAKE_TAG
 go build .\client

--- a/desktop/scripts/build-pt-snowflake.sh
+++ b/desktop/scripts/build-pt-snowflake.sh
@@ -5,7 +5,7 @@ OS=$(uname -s)
 
 mkdir -p ./build/snowflake
 cd ./build/snowflake
-git clone https://git.torproject.org/pluggable-transports/snowflake.git || echo "already cloned"
+git clone https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake.git || echo "already cloned"
 cd snowflake
 git checkout $SNOWFLAKE_TAG
 if [ "$OS" == "Darwin" ]; then

--- a/flatpak/org.onionshare.OnionShare.yaml
+++ b/flatpak/org.onionshare.OnionShare.yaml
@@ -107,7 +107,7 @@ modules:
       - type: git
         url: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib
         commit: 13b7b3552e1eef32e4d8a2a7813f22488f91dc09
-        dest: src/gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib.git
+        dest: src/git.torproject.org/pluggable-transports/goptlib.git
       - type: git
         url: https://github.com/dsnet/compress
         commit: f66993602bf5da07ef49d35b08e7264ae9fe2b6e
@@ -122,7 +122,7 @@ modules:
       env:
         GOBIN: "/app/bin/"
     build-commands:
-      - ". /usr/lib/sdk/golang/enable.sh; export GOPATH=$PWD; export GO111MODULE=off; go install gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/meek.git/meek-client"
+      - ". /usr/lib/sdk/golang/enable.sh; export GOPATH=$PWD; export GO111MODULE=off; go install git.torproject.org/pluggable-transports/meek.git/meek-client"
     sources:
       - type: git
         url: https://go.googlesource.com/net
@@ -143,11 +143,11 @@ modules:
       - type: git
         url: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib
         commit: 13b7b3552e1eef32e4d8a2a7813f22488f91dc09
-        dest: src/gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib.git
+        dest: src/git.torproject.org/pluggable-transports/goptlib.git
       - type: git
         url: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/meek
         commit: 6600c52acb7979b08dd0916a7a779dd0e5dde0b0
-        dest: src/gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/meek.git
+        dest: src/git.torproject.org/pluggable-transports/meek.git
       - type: git
         url: https://github.com/refraction-networking/utls
         commit: 0b2885c8c0d4467cfe98136748a9d011d0b8fff0
@@ -158,7 +158,7 @@ modules:
       env:
         GOBIN: "/app/bin/"
     build-commands:
-      - ". /usr/lib/sdk/golang/enable.sh; export GOPATH=$PWD; export GO111MODULE=off; go install gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake.git/client"
+      - ". /usr/lib/sdk/golang/enable.sh; export GOPATH=$PWD; export GO111MODULE=off; go install git.torproject.org/pluggable-transports/snowflake.git/client"
       - "mv /app/bin/client /app/bin/snowflake-client"
     sources:
       - type: git
@@ -184,11 +184,11 @@ modules:
       - type: git
         url: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib
         commit: 13b7b3552e1eef32e4d8a2a7813f22488f91dc09
-        dest: src/gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib.git
+        dest: src/git.torproject.org/pluggable-transports/goptlib.git
       - type: git
         url: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake
         commit: 36f03dfd4483922b3e7400dedc71df9cf2f30b6b
-        dest: src/gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake.git
+        dest: src/git.torproject.org/pluggable-transports/snowflake.git
       - type: git
         url: https://github.com/refraction-networking/utls
         commit: 0b2885c8c0d4467cfe98136748a9d011d0b8fff0

--- a/flatpak/org.onionshare.OnionShare.yaml
+++ b/flatpak/org.onionshare.OnionShare.yaml
@@ -105,9 +105,9 @@ modules:
         commit: 8c58ed0e35502a485538e4c5ec086070840f3410
         dest: src/filippo.io/edwards25519
       - type: git
-        url: https://git.torproject.org/pluggable-transports/goptlib
+        url: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib
         commit: 13b7b3552e1eef32e4d8a2a7813f22488f91dc09
-        dest: src/git.torproject.org/pluggable-transports/goptlib.git
+        dest: src/gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib.git
       - type: git
         url: https://github.com/dsnet/compress
         commit: f66993602bf5da07ef49d35b08e7264ae9fe2b6e
@@ -122,7 +122,7 @@ modules:
       env:
         GOBIN: "/app/bin/"
     build-commands:
-      - ". /usr/lib/sdk/golang/enable.sh; export GOPATH=$PWD; export GO111MODULE=off; go install git.torproject.org/pluggable-transports/meek.git/meek-client"
+      - ". /usr/lib/sdk/golang/enable.sh; export GOPATH=$PWD; export GO111MODULE=off; go install gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/meek.git/meek-client"
     sources:
       - type: git
         url: https://go.googlesource.com/net
@@ -141,13 +141,13 @@ modules:
         commit: faf0a1b62c6b439486fd1d914d8185627b99d387
         dest: src/golang.org/x/sys
       - type: git
-        url: https://git.torproject.org/pluggable-transports/goptlib
+        url: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib
         commit: 13b7b3552e1eef32e4d8a2a7813f22488f91dc09
-        dest: src/git.torproject.org/pluggable-transports/goptlib.git
+        dest: src/gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib.git
       - type: git
-        url: https://git.torproject.org/pluggable-transports/meek
+        url: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/meek
         commit: 6600c52acb7979b08dd0916a7a779dd0e5dde0b0
-        dest: src/git.torproject.org/pluggable-transports/meek.git
+        dest: src/gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/meek.git
       - type: git
         url: https://github.com/refraction-networking/utls
         commit: 0b2885c8c0d4467cfe98136748a9d011d0b8fff0
@@ -158,7 +158,7 @@ modules:
       env:
         GOBIN: "/app/bin/"
     build-commands:
-      - ". /usr/lib/sdk/golang/enable.sh; export GOPATH=$PWD; export GO111MODULE=off; go install git.torproject.org/pluggable-transports/snowflake.git/client"
+      - ". /usr/lib/sdk/golang/enable.sh; export GOPATH=$PWD; export GO111MODULE=off; go install gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake.git/client"
       - "mv /app/bin/client /app/bin/snowflake-client"
     sources:
       - type: git
@@ -182,13 +182,13 @@ modules:
         commit: 5ec99f83aff198f5fbd629d6c8d8eb38a04218ca
         dest: src/golang.org/x/xerrors
       - type: git
-        url: https://git.torproject.org/pluggable-transports/goptlib
+        url: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib
         commit: 13b7b3552e1eef32e4d8a2a7813f22488f91dc09
-        dest: src/git.torproject.org/pluggable-transports/goptlib.git
+        dest: src/gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib.git
       - type: git
-        url: https://git.torproject.org/pluggable-transports/snowflake
+        url: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake
         commit: 36f03dfd4483922b3e7400dedc71df9cf2f30b6b
-        dest: src/git.torproject.org/pluggable-transports/snowflake.git
+        dest: src/gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake.git
       - type: git
         url: https://github.com/refraction-networking/utls
         commit: 0b2885c8c0d4467cfe98136748a9d011d0b8fff0


### PR DESCRIPTION
Our CI is failing (at least the flatpak one) since the `git.torproject.org` links for pluggable transports have been updated to `gitlab.torproject.org`. This PR attempts to fix that.