### PR TITLE
Dev script for first time setup in linux

### DIFF
--- a/setup-project.sh
+++ b/setup-project.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+OS=$(uname -s)
+
+if [ "$OS" == "Linux" ]; then
+    # setup environment
+    cd cli
+    poetry install
+    echo "OnionShare CLI is installed!"
+    cd ../desktop
+    poetry install
+
+    # setup tor
+    poetry run python ./scripts/get-tor.py linux-x86_64
+    echo "Tor browser is installed"
+
+    # compile dependencies
+    ./scripts/build-pt-obfs4proxy.sh
+    ./scripts/build-pt-snowflake.sh
+    ./scripts/build-pt-meek.sh
+
+    # add alias
+    echo "alias onionshare='cd $(pwd) && poetry run onionshare'" >> ~/.bash_aliases
+    source ~/.bash_aliases
+
+    echo "OnionShare Desktop is now installed"
+    echo "Try running 'onionshare' to start onionshare server from source tree"
+    echo "Restart a new terminal if the above doesnt work"
+    echo "Checkout desktop/README.md for more info"
+else
+    echo "This script only works in linux distros, Try cli/README.md, desktop/README.md for installation steps"
+    exit 1
+fi


### PR DESCRIPTION
# Dev script for first time setup in linux

- The script assumes the required tools are already installed (poetry and go). I can add installation instructions incase the script fails if these go/poetry is missing. 
- An alias `onionshare` is added at the end to start the server from source on the go.
- The script only works on linux and exits on win, macos

resolves #1922 