### PR TITLE
Added optional filename logging for individual file downloads

### DIFF
--- a/cli/onionshare_cli/__init__.py
+++ b/cli/onionshare_cli/__init__.py
@@ -120,6 +120,13 @@ def main(cwd=None):
         help="Share files: Continue sharing after files have been sent (default is to stop sharing)",
     )
     parser.add_argument(
+        "--log-filenames",
+        action="store_true",
+        dest="log_filenames",
+        default=False,
+        help="Share files: Log individual names of shared files as they are downloaded (requires autostop sharing to be disabled)"
+    )
+    parser.add_argument(
         "--qr",
         action="store_true",
         dest="qr",
@@ -204,6 +211,7 @@ def main(cwd=None):
     disable_files = args.disable_files
     disable_csp = bool(args.disable_csp)
     custom_csp = args.custom_csp
+    log_filenames = bool(args.log_filenames)
     verbose = bool(args.verbose)
 
     # Verbose mode?
@@ -242,6 +250,7 @@ def main(cwd=None):
             mode_settings.set("persistent", "mode", mode)
         if mode == "share":
             mode_settings.set("share", "autostop_sharing", autostop_sharing)
+            mode_settings.set("share", "log_filenames", log_filenames)
         if mode == "receive":
             if data_dir:
                 mode_settings.set("receive", "data_dir", data_dir)
@@ -298,6 +307,10 @@ def main(cwd=None):
         # Save the filenames in persistent file
         if persistent_filename:
             mode_settings.set(mode, "filenames", filenames)
+
+        if autostop_sharing and log_filenames:
+            print("Autostop sharing is enabled, thus individual files cannot be downloaded (or logged). Set both --no-autostop-sharing and --log-filenames for intended functionality.")
+            sys.exit()
 
     # In receive mode, you must allows either text, files, or both
     if mode == "receive" and disable_text and disable_files:

--- a/cli/onionshare_cli/mode_settings.py
+++ b/cli/onionshare_cli/mode_settings.py
@@ -48,7 +48,11 @@ class ModeSettings:
                 "autostop_timer": False,
                 "service_id": None,
             },
-            "share": {"autostop_sharing": True, "filenames": []},
+            "share": {
+                "autostop_sharing": True,
+                "filenames": [],
+                "log_filenames": False,
+                },
             "receive": {
                 "data_dir": self.build_default_receive_data_dir(),
                 "webhook_url": None,

--- a/cli/onionshare_cli/web/send_base_mode.py
+++ b/cli/onionshare_cli/web/send_base_mode.py
@@ -245,8 +245,14 @@ class SendBaseModeWeb:
                             or self.common.platform == "Linux"
                             or self.common.platform == "BSD"
                         ):
+                            if self.web.settings.get("share", "log_filenames"):
+                                filename_str = "{0} - ".format(os.path.basename(file_to_download))
+                            else:
+                                filename_str = ""
+                            
                             sys.stdout.write(
-                                "\r{0:s}, {1:.2f}%          ".format(
+                                "\r{0}{1:s}, {2:.2f}%          ".format(
+                                    filename_str,
                                     self.common.human_readable_filesize(
                                         downloaded_bytes
                                     ),


### PR DESCRIPTION
Fixes #1911. Adds the `--log-filenames` argument which when combined with `--no-autostop-sharing`, will log the filename of each shared file that gets downloaded.

## Screenshots

*without `--log-filenames` (appearance unchanged)*
<img src="https://github.com/user-attachments/assets/56960729-1fd6-4862-9090-58850bd16d59" width="50%">

*with `--log-filenames`*
<img src="https://github.com/user-attachments/assets/852546a6-d0ac-4d3b-9e49-1e37e83dd8f6" width="50%">

------

Being that this is my first contrib here feel free to let me know if anything should be changed/is missing! Cheers!
