### PR TITLE
Unquote path names in --log-filenames mode

### DIFF
--- a/cli/onionshare_cli/web/send_base_mode.py
+++ b/cli/onionshare_cli/web/send_base_mode.py
@@ -25,7 +25,7 @@ import mimetypes
 import gzip
 from flask import Response, request
 from unidecode import unidecode
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 
 class SendBaseModeWeb:
@@ -246,7 +246,10 @@ class SendBaseModeWeb:
                             or self.common.platform == "BSD"
                         ):
                             if self.web.settings.get(self.web.mode, "log_filenames"):
-                                filename_str = f"{path} - "
+                                # Decode and sanitize the path to remove newlines
+                                decoded_path = unquote(path)
+                                decoded_path = decoded_path.replace("\r", "").replace("\n", "")
+                                filename_str = f"{decoded_path} - "
                             else:
                                 filename_str = ""
                             

--- a/cli/onionshare_cli/web/share_mode.py
+++ b/cli/onionshare_cli/web/share_mode.py
@@ -29,7 +29,7 @@ from datetime import datetime, timezone
 from flask import Response, request, render_template, make_response, abort
 from unidecode import unidecode
 from werkzeug.http import parse_date, http_date
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 from .send_base_mode import SendBaseModeWeb
 
@@ -347,7 +347,10 @@ class ShareModeWeb(SendBaseModeWeb):
                         or self.common.platform == "BSD"
                     ):
                         if self.web.settings.get("share", "log_filenames"):
-                            filename_str = f"{path} - "
+                            # Decode and sanitize the path to remove newlines
+                            decoded_path = unquote(path)
+                            decoded_path = decoded_path.replace("\r", "").replace("\n", "")
+                            filename_str = f"{decoded_path} - "
                         else:
                             filename_str = ""
 


### PR DESCRIPTION
Follow up to https://github.com/onionshare/onionshare/pull/1932

I wasn't sure if the terminal printing the paths (filenames) would be subject to the same security concerns as what we found with the desktop/history tab fix (https://github.com/onionshare/onionshare/commit/aae0f8f045eafcc88d70b23cdc1e7e38c39fae23)

But since it is ultimately potentially untrusted input (the paths requested might not be valid and could be somehow malicious, maybe this could trigger an unknown bug in a terminal?) I thought just in case, I'd apply the same changes here as what we did on the frontend last year.