### PR TITLE
Encode the file name when adding it to the 'link' attribute of each file. This lets the file be downloaded if it has a special character e.g #.

### DIFF
--- a/cli/onionshare_cli/web/send_base_mode.py
+++ b/cli/onionshare_cli/web/send_base_mode.py
@@ -170,18 +170,18 @@ class SendBaseModeWeb:
             if is_dir:
                 if add_trailing_slash:
                     dirs.append(
-                        {"link": os.path.join(f"/{path}", filename, ""), "basename": filename}
+                        {"link": os.path.join(f"/{path}", quote(filename), ""), "basename": filename}
                     )
                 else:
                     dirs.append(
-                        {"link": os.path.join(f"/{path}", filename), "basename": filename}
+                        {"link": os.path.join(f"/{path}", quote(filename)), "basename": filename}
                     )
             else:
                 size = os.path.getsize(this_filesystem_path)
                 size_human = self.common.human_readable_filesize(size)
                 files.append(
                     {
-                        "link": os.path.join(f"/{path}", filename),
+                        "link": os.path.join(f"/{path}", quote(filename)),
                         "basename": filename,
                         "size_human": size_human,
                     }


### PR DESCRIPTION
Fixes #1919.

To test, you can create the special file:

```
echo hi > '/home/user/[#AnimeNSK]_The_New_Gate_-_01_[HDTV_1920x1080]_[HEVC_10Bit]_(C5E202B8).mkv'
```

Then share it in either Share or Website mode, ensuring you turn off 'Stop sharing after files have been downloaded' (so that it turns into a hyperlink rather than have to use the Downloads button). 

With this patch, it should be downloadable, and you can see in the html source of the page that it renders like this:

```
        <a href="/%5B%23AnimeNSK%5D_The_New_Gate_-_01_%5BHDTV_1920x1080%5D_%5BHEVC_10Bit%5D_%28C5E202B8%29.mkv">
```

Without, it will get the 404 on `/[` as per the bug report.