### PR TITLE
Replace libgtk-3-0 with libgtk-3-0t64 which might help building on armhf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,7 +73,7 @@ parts:
       - libgl1
       - libglvnd0
       - libglx0
-      - libgtk-3-0
+      - libgtk-3-0t64
       - libharfbuzz0b
       - libjpeg8
       - liblcms2-2


### PR DESCRIPTION
Trying to solve the error `Stage package not found in part 'onionshare': libgtk-3-0.` on armhf in snapcraft.

I read https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1959862.html and am seeing if this helps.