### PR TITLE
3 more libraries that need an armhf-compatible version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,10 +62,10 @@ parts:
       - PYTHONPATH: ""
     stage-packages:
       - libasound2
-      - libatk1.0-0
+      - libatk1.0-0t64
       - libcairo2
       - libcairo-gobject2
-      - libcups2
+      - libcups2t64
       - libdrm2
       - libegl1
       - libfreetype6
@@ -81,7 +81,7 @@ parts:
       - libnss3
       - libpango-1.0-0
       - libpangocairo-1.0-0
-      - libpng16-16
+      - libpng16-16t64
       - libpq5
       - libpulse-mainloop-glib0
       - librsvg2-2


### PR DESCRIPTION
A few more libraries that for armhf need a different package. (amd64/arm64 seem to automatically select these, not sure why armhf doesn't)