### PR TITLE
Call t.join() to wait for the web thread to stop before cleaning up the onion. Seems to fix periodic race condition segfault

### DIFF
--- a/cli/onionshare_cli/__init__.py
+++ b/cli/onionshare_cli/__init__.py
@@ -541,6 +541,7 @@ def main(cwd=None):
     finally:
         # Shutdown
         web.cleanup()
+        t.join()
         onion.cleanup()
 
 


### PR DESCRIPTION
Fixes https://github.com/onionshare/onionshare/issues/1973

As far as I can tell, this is enough to fix the issue.

I used to reproduce the issue every 1 to 5 tries with `poetry run onionshare-cli --local-only --chat --auto-stop-timer 2`.

Now I can't reproduce it, and I've been running it on a loop for quite a while now:

```
while true; do poetry run onionshare-cli --local-only --chat --auto-stop-timer 2; if [ $? -ne 0 ]; then break; fi; done
```