### PR TITLE
Remove armhf from snap since there are no pyside6 packages for it on pypi

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,6 @@ confinement: strict
 platforms:
   amd64:
   arm64:
-  armhf:
 
 apps:
   onionshare:


### PR DESCRIPTION
As discussed. armhf builds on snap fail with:

```
:: ERROR: Could not find a version that satisfies the requirement pyside6-addons==6.8.2.1 (from versions: none)
:: ERROR: No matching distribution found for pyside6-addons==6.8.2.1
```

I don't think there's anything we can feasibly do about supporting armhf until Qt publish PySide6 wheels for armhf. For now, removing it..