### PR TITLE
Try to gracefully fall back to gevent-less SocketIO if it is not supported (#1510)

### DIFF
--- a/cli/onionshare_cli/web/web.py
+++ b/cli/onionshare_cli/web/web.py
@@ -176,11 +176,17 @@ class Web:
             self.website_mode = WebsiteModeWeb(self.common, self)
         elif self.mode == "chat":
             if self.common.verbose:
-                self.socketio = SocketIO(
-                    async_mode="gevent", logger=True, engineio_logger=True
-                )
+                try:
+                    self.socketio = SocketIO(
+                        async_mode="gevent", logger=True, engineio_logger=True
+                    )
+                except ValueError:
+                    self.socketio = SocketIO(logger=True, engineio_logger=True)
             else:
-                self.socketio = SocketIO(async_mode="gevent")
+                try:
+                    self.socketio = SocketIO(async_mode="gevent")
+                except ValueError:
+                    self.socketio = SocketIO()
             self.socketio.init_app(self.app)
             self.chat_mode = ChatModeWeb(self.common, self)
 


### PR DESCRIPTION
Fixes #1510 (I hope) - hard to test personally, but the issue sounds pretty straightforward: a ValueError is thrown if there is no gevent for SocketIO's async mode. 

Affected downstream OS have been patching it to remove the async_mode and this apparently works for them.

This shouldn't affect systems that do support the gevent async mode already. Chat is working ok for me on Debian 12 with this patch.