### PR TITLE
Properly set the web 'done' state to True on loading the directory listing

### DIFF
--- a/cli/onionshare_cli/__init__.py
+++ b/cli/onionshare_cli/__init__.py
@@ -515,7 +515,7 @@ def main(cwd=None):
                 if not app.autostop_timer_thread.is_alive():
                     if mode == "share":
                         # If there were no attempts to download the share, or all downloads are done, we can stop
-                        if web.share_mode.cur_history_id == 0 or web.done:
+                        if not web.share_mode.download_in_progress or web.share_mode.cur_history_id == 0 or web.done:
                             print("Stopped because auto-stop timer ran out")
                             web.stop(app.port)
                             break


### PR DESCRIPTION
The share sometimes does not stop as expected in 'auto-stop timer' mode when the timer runs out, in very specific conditions:

1) CLI tool must be used (the desktop version is not affected)
2) Auto-stop-timer must be set (it's not an issue for 'stop after files are downloaded')
3) Someone must've visited the onion at least once (if no-one has ever visited, it would still stop when the timer runs out).
4) Only the 'Share' mode is affected (not receive, website, or chat)

This PR fixes the issue.