### PR TITLE
Catch general Exception in the UI when trying to connect or start a share, and raise as Alert

### DIFF
--- a/desktop/onionshare/resources/locale/en.json
+++ b/desktop/onionshare/resources/locale/en.json
@@ -247,6 +247,7 @@
     "error_port_not_available": "OnionShare port not available",
     "history_receive_read_message_button": "Read Message",
     "error_tor_protocol_error": "There was an error with Tor: {}",
+    "error_generic": "There was an unexpected error with OnionShare:\n{}",
     "moat_contact_label": "Contacting BridgeDB…",
     "moat_captcha_label": "Solve the CAPTCHA to request a bridge.",
     "moat_captcha_placeholder": "Enter the characters from the image",

--- a/desktop/onionshare/threads.py
+++ b/desktop/onionshare/threads.py
@@ -106,6 +106,11 @@ class OnionThread(QtCore.QThread):
             message = self.mode.common.gui.get_translated_tor_error(e)
             self.error.emit(message)
             return
+        except Exception as e:
+            # Handle any other error that wasn't in the list above
+            message = strings._("error_generic").format(e.args[0])
+            self.error.emit(message)
+            return
 
 
 class WebThread(QtCore.QThread):

--- a/desktop/onionshare/tor_connection.py
+++ b/desktop/onionshare/tor_connection.py
@@ -210,6 +210,12 @@ class TorConnectionThread(QtCore.QThread):
             )
             self.error_connecting_to_tor.emit(message)
 
+        except Exception as e:
+            # Handle any other error that wasn't in the list above
+            message = strings._("error_generic").format(e.args[0])
+            self.error_connecting_to_tor.emit(message)
+            return
+
     def _tor_status_update(self, progress, summary):
         self.tor_status_update.emit(progress, summary)
 


### PR DESCRIPTION
Fixes #1719

We basically are capturing a whole bunch of custom raised exceptions from the backend such as Tor timeouts etc, but we weren't capturing any otherwise-undefined Exception.

To test this, put `raise SystemError("Whoops")` just above the final line `return onion_host` in the cli's onion.py `start_onion_service()`, and try to start a Share. 

Or, put it right at the start of onion.py's `connect()`. Then try to connect to Tor itself (e.g starting OnionShare).

This doesn't really have to get into 2.6.3, unless you want to... may need further testing