### PR TITLE
Go back to expecting moat-bridges after captcha submission

### DIFF
--- a/desktop/onionshare/moat_dialog.py
+++ b/desktop/onionshare/moat_dialog.py
@@ -289,7 +289,7 @@ class MoatThread(QtCore.QThread):
                     self.bridgedb_error.emit()
                     return
                 if moat_res["data"][0]["type"] != "moat-challenge":
-                    self.common.log("MoatThread", "run", f"type != moat-challange")
+                    self.common.log("MoatThread", "run", f"type != moat-challenge")
                     self.bridgedb_error.emit()
                     return
 
@@ -351,8 +351,8 @@ class MoatThread(QtCore.QThread):
                         self.captcha_error.emit(errors)
                         return
 
-                if moat_res["data"][0]["type"] != "moat-challenge":
-                    self.common.log("MoatThread", "run", f"type != moat-challenge")
+                if moat_res["data"][0]["type"] != "moat-bridges":
+                    self.common.log("MoatThread", "run", f"type != moat-bridges")
                     self.bridgedb_error.emit()
                     return
 


### PR DESCRIPTION
Fixes #1994

As per https://gitlab.torproject.org/tpo/anti-censorship/rdsys/-/merge_requests/480#note_3161203 , they have gone back to sending `moat-bridges` in the response with bridges after the captcha has been submitted.

I'm going to self merge this simple fix which I've tested.