### PR TITLE
Remove onionshare-cli from poetry desktop venv

### DIFF
--- a/desktop/pyproject.toml
+++ b/desktop/pyproject.toml
@@ -28,4 +28,3 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 onionshare = 'onionshare:main'
-onionshare-cli = 'onionshare_cli:main'


### PR DESCRIPTION
Fixes #1878

Apparently having the cli tool defined in the desktop causes a collision problem for building the CLI wheel.

I originally thought that removing this from `desktop` prevents the `poetry run onionshare-cli` from working in the desktop dir's venv. But now I can't reproduce it (I can run `poetry run onionshare-cli` just fine from `desktop/`).

Even if we couldn't, it still sounds like this is for the best. And with the recent adding of the `setup-project.sh` script, the use of the bash alias can help run the onionshare-cli tool either way in development mode.