### PR TITLE
Tweaks to Download Mode - reworked tab UI to support multiple buttons within tab mode selection

### DIFF
--- a/desktop/onionshare/gui_common.py
+++ b/desktop/onionshare/gui_common.py
@@ -91,9 +91,10 @@ class GuiCommon:
         header_color = "#4E064F"  # purple in light
         title_color = "#333333"  # dark gray color in main window
         stop_button_color = "#d0011b"  # red button color for stopping server
-        new_tab_button_background = "#ffffff"
+        new_tab_button_background = "#dec0fc"
         new_tab_button_border = "#efeff0"
         new_tab_button_text_color = "#4e0d4e"
+        new_tab_button_checked = "#d1d1d1"
         downloads_uploads_progress_bar_border_color = "#4E064F"
         downloads_uploads_progress_bar_chunk_color = "#4E064F"
         share_zip_progess_bar_border_color = "#4E064F"
@@ -108,6 +109,7 @@ class GuiCommon:
             new_tab_button_background = "#5F5F5F"
             new_tab_button_border = "#878787"
             new_tab_button_text_color = "#FFFFFF"
+            new_tab_button_checked = "#6b6b6b"
             share_zip_progess_bar_border_color = "#F2F2F2"
             history_background_color = "#191919"
             history_label_color = "#ffffff"
@@ -115,6 +117,21 @@ class GuiCommon:
 
         return {
             # OnionShareGui styles
+            "collapsible_section": """
+                QWidget {
+                    border-color: #4E064F;
+                    border: 0.5px solid #999999;
+                    border-radius: 5px;
+                    padding: 3px;
+                    font-weight: bold;
+                    font-size: 16px;
+                }
+                QPushButton:checked {
+                    background-color: """
+            + new_tab_button_checked
+            + """;
+                }
+               """,
             "tab_widget": """
                 QTabBar::tab { width: 170px; height: 30px; }
                 """,
@@ -365,19 +382,14 @@ class GuiCommon:
             # New tab
             "new_tab_button_image": """
                 QLabel {
-                    padding: 30px;
+                    padding: 20px;
                     text-align: center;
                 }
                 """,
             "new_tab_button_text": """
-                QLabel {
-                    border: 1px solid """
-            + new_tab_button_border
-            + """;
-                    border-radius: 4px;
-                    background-color: """
-            + new_tab_button_background
-            + """;
+                QPushButton {
+                    font-weight: normal;
+                    font-size: 14px;
                     text-align: center;
                     color: """
             + new_tab_button_text_color
@@ -385,12 +397,13 @@ class GuiCommon:
                 }
                 """,
             "new_tab_title_text": """
-                QLabel {
+                QPushButton {
                     text-align: center;
                     color: """
             + title_color
             + """;
-                    font-size: 16px;
+                    font-size: 14px;
+                    font-weight: bold;
                 }
                 """,
             # Share mode and child widget styles
@@ -477,6 +490,13 @@ class GuiCommon:
                 QCheckBox:disabled {
                     color: #666666;
                 }""",
+            "download_mode_qlineedit": """
+                QLineEdit {
+                    color: """
+            + title_color
+            + """;
+                } 
+              """,
             # Tor Settings dialogs
             "tor_settings_error": """
                 QLabel {

--- a/desktop/onionshare/resources/locale/en.json
+++ b/desktop/onionshare/resources/locale/en.json
@@ -200,6 +200,7 @@
     "gui_new_tab_website_button": "Host a Website",
     "gui_new_tab_chat_button": "Chat Anonymously",
     "gui_new_tab_download_button": "Download from another OnionShare",
+    "gui_main_page_welcome_label": "What do you want to do today?",
     "gui_main_page_share_button": "Start Sharing",
     "gui_main_page_receive_button": "Start Receiving",
     "gui_main_page_website_button": "Start Hosting",

--- a/desktop/onionshare/tab/mode/download_mode/__init__.py
+++ b/desktop/onionshare/tab/mode/download_mode/__init__.py
@@ -94,7 +94,7 @@ class DownloadMode(Mode):
         )
         self.onionshare_url = QtWidgets.QLineEdit()
         self.onionshare_url.setStyleSheet(
-            "QLineEdit { color: black; } QLineEdit::placeholder { color: gray; }"
+            self.common.gui.css["download_mode_qlineedit"]
         )
         self.onionshare_url.setPlaceholderText(
             "http://lldan5gahapx5k7iafb3s4ikijc4ni7gx5iywdflkba5y2ezyg6sjgyd.onion"
@@ -114,7 +114,7 @@ class DownloadMode(Mode):
             strings._("mode_settings_download_onionshare_private_key")
         )
         self.onionshare_private_key.setStyleSheet(
-            "QLineEdit { color: black; } QLineEdit::placeholder { color: gray; }"
+            self.common.gui.css["download_mode_qlineedit"]
         )
         self.onionshare_private_key.hide()
 


### PR DESCRIPTION
This is a sort of add-on to #2014 but it has a slightly more radical adjustment to the new tab screen. 

I thought that it would be better to make a separate PR that contains this extra commit, so that you can consider testing/reviewing it separately to the Download Mode itself.

That is, you may prefer to merge #2014 and work on changes to the UI in your own branch afterward.

Or, you might like what I've done here / find it easier to make further adjustments based on this change. In which case, you could close #2014 and merge this one instead.