### PR TITLE
Use locale.getlocale() instead of deprecated locale.getdefaultlocale()

### DIFF
--- a/cli/onionshare_cli/settings.py
+++ b/cli/onionshare_cli/settings.py
@@ -140,7 +140,7 @@ class Settings(object):
 
         # Choose the default locale based on the OS preference, and fall-back to English
         if self._settings["locale"] is None:
-            language_code, encoding = locale.getdefaultlocale()
+            language_code, encoding = locale.getlocale()
 
             # Default to English
             if not language_code:

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -1,6 +1,6 @@
-import sys
 import os
 import shutil
+import sys
 import tempfile
 
 import pytest
@@ -116,22 +116,22 @@ def default_zw():
 
 @pytest.fixture
 def locale_en(monkeypatch):
-    monkeypatch.setattr("locale.getdefaultlocale", lambda: ("en_US", "UTF-8"))
+    monkeypatch.setattr("locale.getlocale", lambda: ("en_US", "UTF-8"))
 
 
 @pytest.fixture
 def locale_fr(monkeypatch):
-    monkeypatch.setattr("locale.getdefaultlocale", lambda: ("fr_FR", "UTF-8"))
+    monkeypatch.setattr("locale.getlocale", lambda: ("fr_FR", "UTF-8"))
 
 
 @pytest.fixture
 def locale_invalid(monkeypatch):
-    monkeypatch.setattr("locale.getdefaultlocale", lambda: ("xx_XX", "UTF-8"))
+    monkeypatch.setattr("locale.getlocale", lambda: ("xx_XX", "UTF-8"))
 
 
 @pytest.fixture
 def locale_ru(monkeypatch):
-    monkeypatch.setattr("locale.getdefaultlocale", lambda: ("ru_RU", "UTF-8"))
+    monkeypatch.setattr("locale.getlocale", lambda: ("ru_RU", "UTF-8"))
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #2016