### PR TITLE
Fix CLI so that --persistent doesn't require files to be passed in as an arg for share/website mode. Add tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
           poetry run onionshare-cli --local-only --receive --auto-stop-timer 2 --qr --verbose
           poetry run onionshare-cli --local-only --website ../docs --auto-stop-timer 2 --qr --verbose
           poetry run onionshare-cli --local-only --chat --auto-stop-timer 5 --qr --verbose
+          touch /tmp/foo{1,2} && poetry run onionshare-cli --local-only --persistent tests/persistent.json --auto-stop-timer 5 --verbose
 
   test-desktop:
     runs-on: ubuntu-latest

--- a/cli/onionshare_cli/mode_settings.py
+++ b/cli/onionshare_cli/mode_settings.py
@@ -51,6 +51,7 @@ class ModeSettings:
                 "autostart_timer": False,
                 "autostop_timer": False,
                 "service_id": None,
+                "qr": False
             },
             "share": {
                 "autostop_sharing": True,

--- a/cli/tests/persistent.json
+++ b/cli/tests/persistent.json
@@ -1,0 +1,41 @@
+{
+  "onion": {
+    "private_key": "cDGn/lagkwEa62rj+SxSXqFjfSG08fVLVDyZ8HgOS32J9JorEPPWVjDF3GRFolqDTNeUpqNDy39j0E86tqbJag==",
+    "client_auth_priv_key": "TYIU3TRRXWCQBSJYYRKOTR35M32YWNKQ3VBDGFDR74ASOW243OTA",
+    "client_auth_pub_key": "62VXAPXH5HTODLCGL7CNZHA3Q3OKJEPVLV2UGUKQUCZ5GW3YTAAQ"
+  },
+  "persistent": {
+    "mode": "share",
+    "enabled": true,
+    "autostart_on_launch": false
+  },
+  "general": {
+    "title": null,
+    "public": false,
+    "autostart_timer": false,
+    "autostop_timer": true,
+    "service_id": "frlqrdrt4arsgnp4xenzoug5osmfqaqdbniuf4ziejoiwnhju3jlazid",
+    "qr": false
+  },
+  "share": {
+    "autostop_sharing": false,
+    "filenames": [
+      "/tmp/foo1",
+      "/tmp/foo2"
+    ],
+    "log_filenames": false
+  },
+  "receive": {
+    "data_dir": "/tmp",
+    "webhook_url": null,
+    "disable_text": false,
+    "disable_files": false
+  },
+  "website": {
+    "disable_csp": false,
+    "custom_csp": null,
+    "log_filenames": false,
+    "filenames": []
+  },
+  "chat": {}
+}


### PR DESCRIPTION
Fixes #1999

It was already intended that if `--persistent /path/to/persistent/json/file` was passed in for the CLI, that it wouldn't require reading a list of files as a final arg to the CLI tool.

However, a logic error meant that it still would. Basically it was doing this:

1) Is persistent mode enabled? Yes
2) Is the length of the filenames passed in on the CLI non zero? (No, it was zero)
3) (else) Is the length of the filenames passed in zero? Yes
4) (then) delete the persistent json file and abort.

Ouch!

Fixed so that it doesn't check the length of filenames passed in, if the persistent flag is set..

I also spotted an unrelated bug. The `qr`Mode  setting was not being set in the `general` section for CLI, so there would be a key error if you (or the desktop mode) created a persistent json file and you didn't pass in `--qr` as an arg. That's fixed too.

Finally, I created a persistent json file and put it in `cli/tests`, so that we now run an `onionshare-cli` test from the cli that passes in this file, without any filename args - demonstrating that it works as intended.

We will have some docs to update after this but I will get that done separately, before the 2.7 release.