### PR TITLE
flatpak: use `io.qt.PySide.BaseApp` for PySide6

### DIFF
--- a/flatpak/org.onionshare.OnionShare.yaml
+++ b/flatpak/org.onionshare.OnionShare.yaml
@@ -4,6 +4,8 @@ command: onionshare
 runtime: org.kde.Platform
 runtime-version: "6.8"
 sdk: org.kde.Sdk
+base: io.qt.PySide.BaseApp
+base-version: "6.8"
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang
   - org.freedesktop.Sdk.Extension.llvm19
@@ -17,56 +19,16 @@ finish-args:
   - "--talk-name=org.freedesktop.Notifications"
   - "--talk-name=org.freedesktop.secrets"
   - "--filesystem=~/OnionShare:create"
+build-options:
+  env:
+    - BASEAPP_REMOVE_WEBENGINE=1
+    - BASEAPP_DISABLE_NUMPY=1
 cleanup:
   - "/go"
   - "/bin/scripts"
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
 modules:
-  - name: pyside6
-    buildsystem: simple
-    build-commands: []
-    modules:
-      - name: pyside6-essentials
-        only-arches:
-          - x86_64
-        buildsystem: simple
-        build-commands:
-          - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-            --prefix=${FLATPAK_DEST} "pyside6-essentials" --no-build-isolation
-        sources:
-          - type: file
-            url: https://files.pythonhosted.org/packages/d2/f9/aa4ff511ff1f3dd177f7e8f5a635e03fe578fa2045c8d6be4577e7db3b28/PySide6_Essentials-6.8.2.1-cp39-abi3-manylinux_2_28_x86_64.whl
-            sha256: 5ab31e5395a4724102edd6e8ff980fa3f7cde2aa79050763a1dcc30bb914195a
-        modules:
-          - name: shiboken6
-            buildsystem: simple
-            build-commands:
-              - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-                --prefix=${FLATPAK_DEST} "shiboken6" --no-build-isolation
-            sources:
-              - type: file
-                url: https://files.pythonhosted.org/packages/7b/ff/ab4f287b9573e50b5a47c10e2af8feb5abecc3c7431bd5deec135efc969e/shiboken6-6.8.2.1-cp39-abi3-manylinux_2_28_x86_64.whl
-                sha256: c83e90056f13d0872cc4d2b7bf60b6d6e3b1b172f1f91910c0ba5b641af01758
-      - name: pyside6-essentials-aarch64
-        only-arches:
-          - aarch64
-        buildsystem: simple
-        build-commands:
-          - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-            --prefix=${FLATPAK_DEST} "pyside6-essentials" --no-build-isolation
-        sources:
-          - type: file
-            url: https://files.pythonhosted.org/packages/fd/69/595002d860ee58431fe7add081d6f54fff94ae9680f2eb8cd355c1649bb6/PySide6_Essentials-6.8.2.1-cp39-abi3-manylinux_2_39_aarch64.whl
-            sha256: 7aed46f91d44399b4c713cf7387f5fb6f0114413fbcdbde493a528fb8e19f6ed
-        modules:
-          - name: shiboken6
-            buildsystem: simple
-            build-commands:
-              - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-                --prefix=${FLATPAK_DEST} "shiboken6" --no-build-isolation
-            sources:
-              - type: file
-                url: https://files.pythonhosted.org/packages/a6/b0/4fb102eb5260ee06d379769f3c4f0b82ef397c15f1cbbbbb3f6dceb86d5d/shiboken6-6.8.2.1-cp39-abi3-manylinux_2_39_aarch64.whl
-                sha256: 8592401423acc693f51dbbfae5e7493cc3ed6738be79daaf90afa07f4da5bb25
   - name: snowflake-client
     buildsystem: simple
     build-options:


### PR DESCRIPTION
as I've been told at https://github.com/flathub/org.onionshare.OnionShare/pull/18#issuecomment-2640284230

This should make it easier to track and update dependencies.