### PR TITLE
Add system tray icon activation to toggle main window visibility

### DIFF
--- a/desktop/onionshare/main_window.py
+++ b/desktop/onionshare/main_window.py
@@ -71,6 +71,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 QtGui.QIcon(GuiCommon.get_resource_path("images/logo.png"))
             )
         self.system_tray.setContextMenu(menu)
+        self.system_tray.activated.connect(self.systray_activated)
         self.system_tray.show()
 
         # Status bar
@@ -268,6 +269,14 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.system_tray.hide()
         e.accept()
+
+    def systray_activated(self, reason):
+        if reason == QtWidgets.QSystemTrayIcon.ActivationReason.Trigger:
+            if self.isVisible():
+                self.hide()
+            else:
+                self.show()
+                self.bring_to_front()
 
     def event(self, event):
         # Check if color mode switched while onionshare was open, if so, ask user to restart


### PR DESCRIPTION
**Description:**
This pull request introduces a new feature that allows users to toggle the main window's visibility by activating the system tray icon. This enhances user experience by providing a quick way to minimize and restore the application without fully closing it.

**Changes Made:**
- Added a connection for the `activated` signal of the `QSystemTrayIcon` to a new slot `systray_activated`.
- Implemented the `systray_activated` method to handle system tray icon activation events.
- In `systray_activated`, if the activation reason is `Trigger` (e.g., a single click), the method checks the current visibility of the main window.
- If the window is visible, it is hidden; otherwise, it is shown and brought to the front.

**Files Changed:**
- `desktop/onionshare/main_window.py`

**How to Test:**
1. Run the application.
2. The OnionShare icon should appear in the system tray.
3. Click the system tray icon once. The main window should hide.
4. Click the system tray icon again. The main window should reappear and come to the front.
