### PR TITLE
Fix: Update update_processed_size_signal to accept object type

### DIFF
--- a/desktop/onionshare/tab/mode/share_mode/__init__.py
+++ b/desktop/onionshare/tab/mode/share_mode/__init__.py
@@ -424,7 +424,7 @@ class ShareMode(Mode):
 
 
 class ZipProgressBar(QtWidgets.QProgressBar):
-    update_processed_size_signal = QtCore.Signal(int)
+    update_processed_size_signal = QtCore.Signal(object)
 
     def __init__(self, common, total_files_size):
         super(ZipProgressBar, self).__init__()


### PR DESCRIPTION
## Description
Fixes an `OverflowError` in `ZipProgressBar` caused by large file sizes exceeding 32-bit integer limits in the `update_processed_size_signal`.

## Changes Made
- Changed `update_processed_size_signal` from `QtCore.Signal(int)` to `QtCore.Signal(object)` in `ZipProgressBar` to support large file sizes.
- File: `onionshare/tab/mode/share_mode/zip_progress_bar.py`

## Impact
- Resolves `OverflowError` for files > 2GB.
- Maintains existing progress bar functionality.

## Testing
- Tested with files > 2GB to confirm no overflow errors.
- Verified progress bar updates correctly.