### PR TITLE
Increase minimum window height to 800 pixels

### DIFF
--- a/desktop/onionshare/main_window.py
+++ b/desktop/onionshare/main_window.py
@@ -46,7 +46,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Initialize the window
         self.setMinimumWidth(1040)
-        self.setMinimumHeight(700)
+        self.setMinimumHeight(800)
         self.setWindowTitle("OnionShare")
         self.setWindowIcon(QtGui.QIcon(GuiCommon.get_resource_path("images/logo.png")))
 


### PR DESCRIPTION
Fix overlapping text on the Receive tab while the dialog box is opened.

With the previos height of 700 I get some texts overlapped and the Address box cannot display the address correctly:
<img width="1022" height="743" alt="image" src="https://github.com/user-attachments/assets/6da0aee0-98ed-420b-bc03-d325f333d496" />


