### PR TITLE
receive mode: show indeterminate progress and warn user during Tor traversal

### DIFF
--- a/cli/onionshare_cli/resources/static/css/style.css
+++ b/cli/onionshare_cli/resources/static/css/style.css
@@ -369,6 +369,13 @@ div#uploads .upload progress {
   height: 20px;
 }
 
+div#uploads .upload .upload-warning {
+  color: #c97000;
+  font-size: 0.85em;
+  font-weight: bold;
+  margin-top: 4px;
+}
+
 ul.flashes {
   list-style: none;
   margin: 0;

--- a/cli/onionshare_cli/resources/static/js/receive.js
+++ b/cli/onionshare_cli/resources/static/js/receive.js
@@ -48,11 +48,19 @@ $(function () {
         });
       }
 
-      // If it's finished sending all data to the first Tor node, remove cancel button
-      // and update the status
+      // All data has been sent to the first Tor node but has not yet traversed
+      // the full onion circuit to the receiver. Switch the progress bar to
+      // indeterminate so the user understands the transfer is still in progress,
+      // and warn them not to close the tab.
       if (event.loaded == event.total) {
         $('.cancel', ajax.$upload_div).remove();
-        $('.upload-status', ajax.$upload_div).html('<img src="' + staticImgPath + '/ajax.gif" alt="" /> Waiting for data to finish traversing Tor network ...');
+        // Indeterminate mode: removing 'value' makes the bar animate as "in progress"
+        $('progress', ajax.$upload_div).removeAttr('value');
+        $('.upload-status', ajax.$upload_div).html(
+          '<img src="' + staticImgPath + '/ajax.gif" alt="" /> ' +
+          'Sending &mdash; waiting for data to traverse the Tor network &hellip;'
+        );
+        $('.upload-warning', ajax.$upload_div).show();
       }
     }, false);
 
@@ -106,14 +114,23 @@ $(function () {
       <div class="upload-meta">
         <input class="cancel" type="button" value="Cancel" />
         <div class="upload-filename">educational-video.mp4, secret-plans.pdf</div>
-        <div class="upload-status">Sending to first Tor node ...</div>
+        <div class="upload-status">Sending data to initial Tor node ...</div>
+        <div class="upload-warning" style="display:none">Do not close this tab ...</div>
       </div>
       <progress value="25" max="100"></progress>
-    </div> */
+    </div>
+    Once all bytes reach the first Tor node, 'value' is removed from <progress>
+    (making it indeterminate), the warning div is shown, and the cancel button
+    is removed. */
     var $progress = $('<progress>').attr({ value: '0', max: 100 });
     var $cancel_button = $('<input>').addClass('cancel').attr({ type: 'button', value: 'Cancel' });
     var $upload_filename = $('<div>').addClass('upload-filename').text(filenames.join(', '));
     var $upload_status = $('<div>').addClass('upload-status').text('Sending data to initial Tor node ...');
+    // Warning shown only once data has cleared the first hop and is traversing the circuit.
+    // Hidden by default; revealed in the progress handler above.
+    var $upload_warning = $('<div>').addClass('upload-warning').hide().text(
+      'Do not close this tab until the submission is complete.'
+    );
 
     var $upload_div = $('<div>')
       .addClass('upload')
@@ -122,6 +139,7 @@ $(function () {
           .append($cancel_button)
           .append($upload_filename)
           .append($upload_status)
+          .append($upload_warning)
       )
       .append($progress);
 

--- a/cli/tests/test_cli_web.py
+++ b/cli/tests/test_cli_web.py
@@ -139,6 +139,24 @@ class TestWeb:
             res.get_data()
             assert res.status_code == 200
 
+    def test_receive_mode_page_has_upload_ui(self, temp_dir, common_obj):
+        """
+        The receive index page must include the #uploads container and the
+        receive.js script reference. The JS upload-progress UX (including the
+        indeterminate progress bar and the Tor-traversal warning added in
+        issue #1876) is appended into #uploads at runtime; if either element
+        is missing the warning will silently never appear.
+        """
+        web = web_obj(temp_dir, common_obj, "receive")
+        with web.app.test_client() as c:
+            res = c.get("/")
+            html = res.get_data(as_text=True)
+            assert res.status_code == 200
+            # Container where JS appends upload-progress divs
+            assert 'id="uploads"' in html
+            # Script that drives the upload progress UX
+            assert "receive.js" in html
+
     def test_receive_mode_webhook(self, temp_dir, common_obj):
         global webhook_url, webhook_data
         webhook_url = None


### PR DESCRIPTION
Fixes #1876

## What changed

When a file upload reaches **100% in the browser**, the data has only reached the **first Tor hop**. It still needs to traverse the rest of the onion circuit before arriving at the receiver.

Previously, the progress bar remained at **100%** (visually appearing “done”), which could mislead users into closing the tab before the transfer actually completed.

## Fix

* Switch the `<progress>` element to **indeterminate** (remove the `value` attribute) once all bytes leave the browser. This makes the bar animate as “still working” instead of appearing finished.
* Show a warning message:
  *“Do not close this tab until the submission is complete.”*
* Clarify the status text to reflect that the transfer is still in progress.

## Testing

* `cd cli && poetry run pytest tests/ -q` — **248 passed**
* Manual test:

  1. Open receive mode.
  2. Upload a large file over a slow connection.
  3. Verify the progress bar switches to **indeterminate** and the warning appears after the local send completes.