### PR TITLE
License: change copyright year to 2026

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 (Note: Third-party licenses can be found under licenses/.)
 
 OnionShare
-Copyright (C) 2014-2022 Micah Lee, et al. <micah@micahflee.com>
+Copyright (C) 2014-2026 Micah Lee, et al. <micah@micahflee.com>
 
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007


### PR DESCRIPTION
Updates the copyright year of the license from 2024 to 2026