### PR TITLE
Store temporary files under XDG cache dir on Linux/BSD

### DIFF
--- a/cli/onionshare_cli/common.py
+++ b/cli/onionshare_cli/common.py
@@ -430,11 +430,34 @@ class Common:
         os.makedirs(onionshare_data_dir, 0o700, True)
         return onionshare_data_dir
 
+    def build_cache_dir(self):
+        """
+        Returns the path of the OnionShare cache directory, which holds
+        non-essential data that can safely be deleted. On Linux and BSD this
+        follows the XDG Base Directory Specification (~/.cache/onionshare);
+        on Windows and macOS cache data lives inside the data directory.
+        """
+        if self.platform == "Windows" or self.platform == "Darwin":
+            onionshare_cache_dir = os.path.join(self.build_data_dir(), "cache")
+        else:
+            try:
+                xdg_cache_home = os.environ["XDG_CACHE_HOME"]
+                onionshare_cache_dir = f"{xdg_cache_home}/onionshare"
+            except Exception:
+                onionshare_cache_dir = os.path.expanduser("~/.cache/onionshare")
+
+            # Modify the cache dir if running tests
+            if getattr(sys, "onionshare_test_mode", False):
+                onionshare_cache_dir += "-testdata"
+
+        os.makedirs(onionshare_cache_dir, 0o700, True)
+        return onionshare_cache_dir
+
     def build_tmp_dir(self):
         """
         Returns path to a folder that can hold temporary files
         """
-        tmp_dir = os.path.join(self.build_data_dir(), "tmp")
+        tmp_dir = os.path.join(self.build_cache_dir(), "tmp")
         os.makedirs(tmp_dir, 0o700, True)
         return tmp_dir
 


### PR DESCRIPTION
## Summary

OnionShare currently keeps its `tmp` working directory inside the config directory (`~/.config/onionshare/tmp`). Per the XDG Base Directory Specification, disposable cache data belongs in `$XDG_CACHE_HOME` (defaulting to `~/.cache`). This PR adds a `build_cache_dir()` helper that resolves to `~/.cache/onionshare` on Linux/BSD (honoring `$XDG_CACHE_HOME`), and moves the temporary files directory there. On Windows and macOS, cache data stays inside the existing platform data directory, so nothing changes on those platforms.

All temporary-file consumers (`onion.py`, `share_mode.py`, `send_base_mode.py`, `moat_dialog.py`) already go through `common.build_tmp_dir()`, so this single change covers them. The test-mode `-testdata` suffix behavior is preserved.

Fixes #2052

## Changes

- `cli/onionshare_cli/common.py`: add `build_cache_dir()` and base `build_tmp_dir()` on it