### PR TITLE
Warn when Receive Mode save folder is not writable

### DIFF
--- a/desktop/onionshare/resources/locale/en.json
+++ b/desktop/onionshare/resources/locale/en.json
@@ -24,6 +24,7 @@
     "gui_receive_stop_server": "Stop Receive Mode",
     "gui_receive_stop_server_autostop_timer": "Stop Receive Mode ({} remaining)",
     "gui_receive_flatpak_data_dir": "Because you installed OnionShare using Flatpak, you must save files to a folder in ~/OnionShare.",
+    "gui_receive_data_dir_not_writable": "OnionShare cannot write to this folder:\n\n{}\n\nChoose a folder you can write to (for example your Downloads folder), then try again.",
     "gui_copy_url": "Copy Address",
     "gui_copy_client_auth": "Copy Private Key",
     "gui_canceled": "Canceled",

--- a/desktop/onionshare/tab/mode/receive_mode/__init__.py
+++ b/desktop/onionshare/tab/mode/receive_mode/__init__.py
@@ -209,6 +209,25 @@ class ReceiveMode(Mode):
         """
         return "receive"
 
+    @staticmethod
+    def is_data_dir_writable(path):
+        """
+        Return True if path is an existing directory we can create files in.
+
+        Uses a real write probe so AppArmor/sandbox restrictions (e.g. Tails)
+        are detected even when os.access is optimistic.
+        """
+        if not path or not os.path.isdir(path):
+            return False
+        try:
+            test_path = os.path.join(path, ".onionshare-write-test")
+            with open(test_path, "w", encoding="utf-8") as f:
+                f.write("ok")
+            os.remove(test_path)
+            return True
+        except OSError:
+            return False
+
     def data_dir_button_clicked(self):
         """
         Browse for a new OnionShare data directory, and save to tab settings
@@ -224,6 +243,14 @@ class ReceiveMode(Mode):
                 if not selected_dir.startswith(os.path.expanduser("~/OnionShare")):
                     Alert(self.common, strings._("gui_receive_flatpak_data_dir"))
                     return
+
+            if not self.is_data_dir_writable(selected_dir):
+                Alert(
+                    self.common,
+                    strings._("gui_receive_data_dir_not_writable").format(selected_dir),
+                    QtWidgets.QMessageBox.Warning,
+                )
+                return
 
             self.common.log(
                 "ReceiveMode",
@@ -298,6 +325,20 @@ class ReceiveMode(Mode):
             )
             self.web.receive_mode.can_upload = False
             return False
+
+    def start_server(self):
+        """
+        Start Receive Mode only if the save directory is writable.
+        """
+        data_dir = self.settings.get("receive", "data_dir")
+        if not self.is_data_dir_writable(data_dir):
+            Alert(
+                self.common,
+                strings._("gui_receive_data_dir_not_writable").format(data_dir),
+                QtWidgets.QMessageBox.Warning,
+            )
+            return
+        super().start_server()
 
     def start_server_custom(self):
         """

--- a/desktop/tests/test_receive_data_dir_writable.py
+++ b/desktop/tests/test_receive_data_dir_writable.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for ReceiveMode save-folder writability checks (#2062)."""
+
+import os
+import stat
+import tempfile
+
+# Desktop tests run with the onionshare package on PYTHONPATH
+from onionshare.tab.mode.receive_mode import ReceiveMode
+
+
+def test_is_data_dir_writable_ok(tmp_path):
+    assert ReceiveMode.is_data_dir_writable(str(tmp_path)) is True
+
+
+def test_is_data_dir_writable_missing():
+    assert (
+        ReceiveMode.is_data_dir_writable("/path/that/does/not/exist-onionshare")
+        is False
+    )
+
+
+def test_is_data_dir_writable_file_not_dir(tmp_path):
+    f = tmp_path / "file.txt"
+    f.write_text("x", encoding="utf-8")
+    assert ReceiveMode.is_data_dir_writable(str(f)) is False
+
+
+def test_is_data_dir_writable_readonly_dir():
+    # Best-effort: skip if this OS cannot make a non-writable directory (e.g. Windows)
+    with tempfile.TemporaryDirectory() as d:
+        try:
+            os.chmod(d, stat.S_IRUSR | stat.S_IXUSR)
+            if ReceiveMode.is_data_dir_writable(d):
+                # Platform did not honor read-only; don't fail the suite
+                return
+            assert ReceiveMode.is_data_dir_writable(d) is False
+        finally:
+            try:
+                os.chmod(d, stat.S_IRWXU)
+            except OSError:
+                pass


### PR DESCRIPTION
## Summary

Fixes #2062.

Receive Mode allowed selecting a non-writable folder (e.g. `/root` under Tails AppArmor) and starting with no warning. Uploads then failed only when files arrived.

### Changes
- Probe writability with a real create/delete test (better than `os.access` alone for sandboxes)
- Reject non-writable folders when browsing
- Block **Start Receive Mode** until a writable folder is chosen
- English string `gui_receive_data_dir_not_writable`
- Unit tests for the probe helper

### Testing
- Unit tests for writable dir / missing path / file path
- Manual GUI check recommended on Linux/Tails if available