### PR TITLE
fix: reject /upload once autostop timer expires instead of crashing

### DIFF
--- a/cli/onionshare_cli/web/receive_mode.py
+++ b/cli/onionshare_cli/web/receive_mode.py
@@ -103,6 +103,22 @@ class ReceiveModeWeb:
             Handle the upload files POST request, though at this point, the files have
             already been uploaded and saved to their correct locations.
             """
+            # /upload-ajax already rejects requests once the autostop timer has
+            # expired, but plain (non-JS) form submissions hit this route
+            # directly. Without this check, ReceiveModeRequest.__init__ never
+            # initializes told_gui_about_request/includes_message (it only does
+            # so when can_upload is True), so touching request.includes_message
+            # or parsing request.files below raises an AttributeError and
+            # returns a 500 instead of a normal error page.
+            if not self.can_upload:
+                if ajax:
+                    return json.dumps(
+                        {"error_flashes": ["Uploads are no longer being accepted"]}
+                    )
+                else:
+                    flash("Uploads are no longer being accepted", "error")
+                    return redirect("/")
+
             message_received = request.includes_message
 
             files_received = 0


### PR DESCRIPTION
## Summary

When the autostop timer expires while a Receive Mode upload is in progress, a follow-up upload sent via the plain (non-JS) `/upload` form endpoint crashes with a 500 error instead of being rejected cleanly. `/upload-ajax` already guards against this (`if not self.can_upload: return self.web.error403()`), but the non-ajax `/upload` route has no equivalent check.

Root cause: `ReceiveModeRequest.__init__` only initializes `told_gui_about_request`, `includes_message`, `history_id`, etc. inside `if self.web.receive_mode.can_upload:`. When `can_upload` is `False`, none of those attributes are set. The `upload()` view still unconditionally accesses `request.includes_message` as its first statement, and (if that didn't already raise) subsequently triggers multipart parsing via `request.files.getlist(...)`, which calls `_get_file_stream` → `tell_gui_request_started()` → reads `self.told_gui_about_request`, raising `AttributeError` and producing a 500.

## Changes

- `cli/onionshare_cli/web/receive_mode.py`: `upload()` now checks `self.can_upload` first and returns a normal rejection (flash message + redirect for regular form posts, JSON error flash for ajax) instead of falling through into code paths that assume request-tracking attributes were initialized.

Fixes #1254