### PR TITLE
fix: include "+" new tab button in forward keyboard tab order

### DIFF
--- a/desktop/onionshare/main_window.py
+++ b/desktop/onionshare/main_window.py
@@ -130,6 +130,15 @@ class MainWindow(QtWidgets.QMainWindow):
         self.tabs = TabWidget(self.common, self.system_tray, self.status_bar, self)
         self.tabs.bring_to_front.connect(self.bring_to_front)
 
+        # The "+" new tab button is a manually-positioned overlay widget
+        # (see TabWidget.move_new_tab_button), not one placed via a layout,
+        # so Qt's automatically-computed tab order skips over it when
+        # tabbing forward from the settings button, even though shift+tab
+        # correctly lands on it in reverse. Make the order explicit and
+        # symmetric in both directions.
+        self.setTabOrder(self.settings_button, self.tabs.new_tab_button)
+        self.setTabOrder(self.tabs.new_tab_button, self.tabs.tabBar())
+
         # If we have saved persistent tabs, try opening those
         if len(self.common.settings.get("persistent_tabs")) > 0:
             for mode_settings_id in self.common.settings.get("persistent_tabs"):


### PR DESCRIPTION
## Summary

The "+" new-tab button (`TabWidget.new_tab_button`) is a manually-positioned overlay widget — it's a child of `TabWidget` positioned with `.move()`/`.raise_()` in `move_new_tab_button()`, not placed via a layout or `setCornerWidget()`. Because of this, Qt's automatically-computed tab order skips over it when tabbing **forward** from the settings button (landing directly on the tab bar instead), even though **shift+tab** correctly reaches it going backward. `setTabOrder()` is the standard Qt fix for exactly this kind of asymmetric auto-computed order.

## Verification

I don't have a way to run the full desktop test suite in this environment (it needs `waitress`/Tor/etc. not installed here), so I built a minimal, offscreen (`QT_QPA_PLATFORM=offscreen`) PySide6 reproduction using the *exact* same widget pattern as the real code — a settings `QPushButton` added to a status bar, followed by a `QTabWidget` subclass whose `+` button is a child `QPushButton` positioned with `.move()`/`.raise_()`, exactly mirroring `TabWidget.__init__`/`move_new_tab_button`. Using `QWidget.focusNextChild()`/`focusPreviousChild()` to simulate Tab/Shift+Tab:

- **Before the fix**: forward-tab from the settings button lands on the `QTabBar`, skipping the "+" button — matches the reported symptom exactly. Backward (shift+tab) from the tab bar correctly lands on the "+" button.
- **After the fix** (adding the two `setTabOrder()` calls): forward-tab from the settings button now correctly lands on the "+" button, and backward navigation still does too — symmetric in both directions.

I'm disclosing this clearly since it's a synthetic reproduction of the widget-hierarchy pattern rather than a run of the actual app end-to-end, but the mechanism (Qt's default tab-chain construction for a non-layout child widget) and the fix (an explicit `setTabOrder`) are the same either way.

## Changes

- `desktop/onionshare/main_window.py`: after constructing `self.tabs` (the `TabWidget`), explicitly chain `settings_button -> tabs.new_tab_button -> tabs.tabBar()` via `setTabOrder()`.

Fixes #1595