### PR TITLE
fix: make Test Connection to Tor result strings translatable

### DIFF
--- a/desktop/onionshare/resources/locale/en.json
+++ b/desktop/onionshare/resources/locale/en.json
@@ -100,6 +100,8 @@
     "gui_settings_version_label": "You are using OnionShare {}",
     "gui_settings_help_label": "Need help? See <a href='https://docs.onionshare.org'>docs.onionshare.org</a>",
     "gui_settings_license_label": "OnionShare is licensed under the GPL v3.<br>Third-party licenses can be viewed here:<br><a href='https://github.com/onionshare/onionshare/tree/main/licenses'>https://github.com/onionshare/onionshare/tree/main/licenses</a>",
+    "gui_settings_true": "Yes",
+    "gui_settings_false": "No",
     "settings_test_success": "Connected to the Tor controller.\n\nTor version: {}\nSupports ephemeral onion services: {}.\nSupports client authentication: {}.\nSupports next-gen .onion addresses: {}.",
     "connecting_to_tor": "Connecting to the Tor network",
     "update_available": "New OnionShare out. <a href='{}'>Click here</a> to get it.<br><br>You are using {} and the latest is {}.",

--- a/desktop/onionshare/tor_settings_tab.py
+++ b/desktop/onionshare/tor_settings_tab.py
@@ -768,13 +768,21 @@ class TorSettingsTab(QtWidgets.QWidget):
         self.save_button.show()
 
         if self.tor_con_type == "test":
+
+            def yes_no(value):
+                return (
+                    strings._("gui_settings_true")
+                    if value
+                    else strings._("gui_settings_false")
+                )
+
             Alert(
                 self.common,
                 strings._("settings_test_success").format(
                     self.test_onion.tor_version,
-                    self.test_onion.supports_ephemeral,
-                    self.test_onion.supports_stealth,
-                    self.test_onion.supports_v3_onions,
+                    yes_no(self.test_onion.supports_ephemeral),
+                    yes_no(self.test_onion.supports_stealth),
+                    yes_no(self.test_onion.supports_v3_onions),
                 ),
                 title=strings._("gui_settings_connection_type_test_button"),
             )


### PR DESCRIPTION
## Summary

The "Test Connection to Tor" result dialog (`settings_test_success`) formats three Python booleans (`supports_ephemeral`, `supports_stealth`, `supports_v3_onions`) directly into the message string, so it always shows the literal English words "True"/"False" regardless of the user's locale - these can't be translated since they never go through `strings._()`.

## Changes

- `desktop/onionshare/resources/locale/en.json`: added two new translatable keys, `gui_settings_true` ("Yes") and `gui_settings_false` ("No").
- `desktop/onionshare/tor_settings_tab.py`: in `tor_con_success`, map each boolean through a small `yes_no()` helper that looks up the new translated strings instead of passing the raw Python bool into `.format()`.

Fixes #983