### PR TITLE
docs: update README install docs link to current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For macOS you can also use [Homebrew](https://brew.sh/):
 brew install --cask onionshare
 ```
 
-See [these instructions](https://docs.onionshare.org/2.6/en/install.html#linux) to install OnionShare in Linux as a Flatpak or Snap package.
+See [these instructions](https://docs.onionshare.org/2.6.5/en/install.html#linux) to install OnionShare in Linux as a Flatpak or Snap package.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

The README's Linux install section links to `https://docs.onionshare.org/2.6/en/install.html#linux`, which serves the outdated 2.6 documentation. This updates it to `2.6.5`, matching the latest release (v2.6.5) and the version currently served at the docs site root.

Fixes #2100

## Changes

- `README.md`: `docs.onionshare.org/2.6/` → `docs.onionshare.org/2.6.5/` in the Linux install instructions link

## Notes

A version-agnostic `/latest/` path would be ideal, but `https://docs.onionshare.org/latest/...` currently 404s, so pinning to the current release version is the minimal reliable fix. The broader version-agnostic-URL discussion is tracked in onionshare/onionshare-website#54.