### PR TITLE
Fix Flatpak drag crash and stale instance lock

### DIFF
--- a/desktop/onionshare/__init__.py
+++ b/desktop/onionshare/__init__.py
@@ -35,6 +35,7 @@ from onionshare_cli.common import Common
 from onionshare_cli.settings import Settings
 
 from .gui_common import GuiCommon
+from .instance_lock import acquire_flatpak_lock
 from .widgets import Alert
 from .main_window import MainWindow
 
@@ -200,49 +201,74 @@ def main():
         if not valid:
             sys.exit()
 
+    flatpak_lock_file = None
+
     # Is there another onionshare-gui running?
-    if os.path.exists(common.gui.lock_filename):
-        with open(common.gui.lock_filename, "r") as f:
-            existing_pid = int(f.read())
-
-        # Is this process actually still running?
-        still_running = True
-        if not psutil.pid_exists(existing_pid):
-            still_running = False
-        else:
-            for proc in psutil.process_iter(["pid", "name", "username"]):
-                if proc.pid == existing_pid:
-                    if (
-                        proc.username() != getpass.getuser()
-                        or "onionshare" not in " ".join(proc.cmdline()).lower()
-                    ):
-                        still_running = False
-
-        if still_running:
+    if common.is_flatpak():
+        # Flatpak PIDs are namespace-local and can be reused after a crash.
+        # Keep an OS-managed lock open for the lifetime of this process instead.
+        flatpak_lock_file, existing_pid = acquire_flatpak_lock(
+            common.gui.lock_filename
+        )
+        if flatpak_lock_file is None:
             print(f"Opening tab in existing OnionShare window (pid {existing_pid})")
 
-            # Make an event for the existing OnionShare window
             if filenames:
                 obj = {"type": "new_share_tab", "filenames": filenames}
             else:
                 obj = {"type": "new_tab"}
 
-            # Write that event to disk
             with open(common.gui.events_filename, "a") as f:
                 f.write(json.dumps(obj) + "\n")
             return
-        else:
-            os.remove(common.gui.lock_filename)
+    else:
+        if os.path.exists(common.gui.lock_filename):
+            with open(common.gui.lock_filename, "r") as f:
+                existing_pid = int(f.read())
 
-    # Write the lock file
-    with open(common.gui.lock_filename, "w") as f:
-        f.write(f"{os.getpid()}\n")
+            still_running = True
+            if not psutil.pid_exists(existing_pid):
+                still_running = False
+            else:
+                for proc in psutil.process_iter(["pid", "name", "username"]):
+                    if proc.pid == existing_pid:
+                        if (
+                            proc.username() != getpass.getuser()
+                            or "onionshare" not in " ".join(proc.cmdline()).lower()
+                        ):
+                            still_running = False
+
+            if still_running:
+                print(
+                    f"Opening tab in existing OnionShare window (pid {existing_pid})"
+                )
+
+                if filenames:
+                    obj = {"type": "new_share_tab", "filenames": filenames}
+                else:
+                    obj = {"type": "new_tab"}
+
+                with open(common.gui.events_filename, "a") as f:
+                    f.write(json.dumps(obj) + "\n")
+                return
+            else:
+                os.remove(common.gui.lock_filename)
+
+        with open(common.gui.lock_filename, "w") as f:
+            f.write(f"{os.getpid()}\n")
+
+    def release_lock():
+        if flatpak_lock_file is not None:
+            # Closing releases flock even after ordinary shutdown. Keep the file
+            # itself so a racing process cannot lock an unlinked inode.
+            flatpak_lock_file.close()
+        elif os.path.exists(common.gui.lock_filename):
+            os.remove(common.gui.lock_filename)
 
     # Allow Ctrl-C to smoothly quit the program instead of throwing an exception
     def signal_handler(s, frame):
         print("\nCtrl-C pressed, quitting")
-        if os.path.exists(common.gui.lock_filename):
-            os.remove(common.gui.lock_filename)
+        release_lock()
         sys.exit(0)
 
     signal.signal(signal.SIGINT, signal_handler)
@@ -257,7 +283,7 @@ def main():
     # Clean up when app quits
     def shutdown():
         main_window.cleanup()
-        os.remove(common.gui.lock_filename)
+        release_lock()
 
     qtapp.aboutToQuit.connect(shutdown)
 

--- a/desktop/onionshare/instance_lock.py
+++ b/desktop/onionshare/instance_lock.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+OnionShare | https://onionshare.org/
+
+Copyright (C) 2014-2026 Micah Lee, et al. <micah@micahflee.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import os
+
+
+def acquire_flatpak_lock(lock_filename):
+    """Acquire the Flatpak GUI instance lock.
+
+    Flatpak processes can reuse namespace-local PIDs between launches. An
+    advisory file lock is owned by the running process instead, and the kernel
+    releases it automatically when that process exits or crashes.
+    """
+    import fcntl
+
+    lock_file = open(lock_filename, "a+")
+
+    try:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        lock_file.seek(0)
+        existing_pid = lock_file.read().strip() or "unknown"
+        lock_file.close()
+        return None, existing_pid
+
+    lock_file.seek(0)
+    lock_file.truncate()
+    lock_file.write(f"{os.getpid()}\n")
+    lock_file.flush()
+
+    return lock_file, None

--- a/desktop/onionshare/tab/mode/file_selection.py
+++ b/desktop/onionshare/tab/mode/file_selection.py
@@ -187,8 +187,9 @@ class FileList(QtWidgets.QListWidget):
         """
         # Drag and drop doesn't work in Flatpak, because of the sandbox
         if self.common.is_flatpak():
-            Alert(self.common, strings._("gui_dragdrop_sandbox_flatpak").format())
             event.ignore()
+            message = strings._("gui_dragdrop_sandbox_flatpak").format()
+            QtCore.QTimer.singleShot(0, lambda: Alert(self.common, message))
             return
 
         if event.mimeData().hasUrls:

--- a/desktop/tests/test_gui_dragdrop.py
+++ b/desktop/tests/test_gui_dragdrop.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+from onionshare.tab.mode import file_selection
+
+
+class FakeDragEvent:
+    def __init__(self):
+        self.ignored = False
+
+    def ignore(self):
+        self.ignored = True
+
+
+def test_flatpak_drag_warning_is_deferred_until_handler_returns(monkeypatch):
+    event = FakeDragEvent()
+    common = SimpleNamespace(is_flatpak=lambda: True)
+    file_list = SimpleNamespace(common=common)
+    scheduled = []
+    alerts = []
+
+    monkeypatch.setattr(file_selection.strings, "_", lambda key: key)
+    monkeypatch.setattr(
+        file_selection.QtCore.QTimer,
+        "singleShot",
+        lambda delay, callback: scheduled.append((delay, callback)),
+    )
+    monkeypatch.setattr(
+        file_selection,
+        "Alert",
+        lambda common, message: alerts.append(message),
+    )
+
+    file_selection.FileList.dragEnterEvent(file_list, event)
+
+    assert event.ignored
+    assert alerts == []
+    assert len(scheduled) == 1
+
+    delay, callback = scheduled[0]
+    assert delay == 0
+    callback()
+
+    assert alerts == ["gui_dragdrop_sandbox_flatpak"]

--- a/desktop/tests/test_gui_instance_lock.py
+++ b/desktop/tests/test_gui_instance_lock.py
@@ -1,0 +1,82 @@
+import os
+import subprocess
+import sys
+
+from onionshare.instance_lock import acquire_flatpak_lock
+
+
+def test_flatpak_lock_reclaims_stale_reused_pid(tmp_path):
+    lock_filename = tmp_path / "lock"
+    lock_filename.write_text(f"{os.getpid()}\n")
+
+    lock_file, existing_pid = acquire_flatpak_lock(str(lock_filename))
+    try:
+        assert lock_file is not None
+        assert existing_pid is None
+        assert lock_filename.read_text() == f"{os.getpid()}\n"
+    finally:
+        lock_file.close()
+
+
+def test_flatpak_lock_blocks_live_instance_and_recovers_after_release(tmp_path):
+    lock_filename = tmp_path / "lock"
+
+    first_lock, existing_pid = acquire_flatpak_lock(str(lock_filename))
+    assert first_lock is not None
+    assert existing_pid is None
+
+    second_lock, existing_pid = acquire_flatpak_lock(str(lock_filename))
+    assert second_lock is None
+    assert existing_pid == str(os.getpid())
+
+    first_lock.close()
+
+    recovered_lock, existing_pid = acquire_flatpak_lock(str(lock_filename))
+    try:
+        assert recovered_lock is not None
+        assert existing_pid is None
+    finally:
+        recovered_lock.close()
+
+
+def test_flatpak_lock_recovers_after_holder_is_killed(tmp_path):
+    lock_filename = tmp_path / "lock"
+    child_code = """
+import sys
+import time
+
+from onionshare.instance_lock import acquire_flatpak_lock
+
+lock_file, existing_pid = acquire_flatpak_lock(sys.argv[1])
+assert lock_file is not None
+assert existing_pid is None
+print("locked", flush=True)
+time.sleep(30)
+"""
+
+    holder = subprocess.Popen(
+        [sys.executable, "-c", child_code, str(lock_filename)],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        assert holder.stdout.readline().strip() == "locked"
+
+        blocked_lock, existing_pid = acquire_flatpak_lock(str(lock_filename))
+        assert blocked_lock is None
+        assert existing_pid == str(holder.pid)
+
+        holder.kill()
+        holder.wait(timeout=5)
+
+        recovered_lock, existing_pid = acquire_flatpak_lock(str(lock_filename))
+        try:
+            assert recovered_lock is not None
+            assert existing_pid is None
+        finally:
+            recovered_lock.close()
+    finally:
+        if holder.poll() is None:
+            holder.kill()
+            holder.wait(timeout=5)


### PR DESCRIPTION
## What changed

Fix both failure modes reported in #2033 for Flatpak builds:

- Reject the unsupported drag event immediately, then defer the modal sandbox warning to the next Qt event-loop turn. This ensures the drag handler has returned before the warning opens.
- Use an advisory `flock` for the Flatpak GUI singleton instead of deciding liveness from the PID stored in the lock file.
- Keep the PID in the lock file for diagnostics and existing-window event routing, but keep the file descriptor locked for the lifetime of the process.
- Leave the Flatpak lock path in place on normal shutdown; closing the descriptor releases the lock, and the kernel also releases it after a crash. This avoids stale PID files blocking the next launch and avoids unlink/recreate inode races.
- Leave the existing non-Flatpak PID-based singleton behavior unchanged.

## Why

The issue has two related symptoms: entering the modal warning while a drag operation is still active can terminate the GUI, and after that crash the Flatpak lock file can remain with a namespace-local PID such as `2`.

A PID-existence check can then mistake an unrelated reused PID for the previous OnionShare process and refuse to start a new instance.

An OS-managed advisory lock tracks the lifetime of the actual process rather than the value of a reusable Flatpak PID.

## Testing

Added regressions for:

- Flatpak drag is ignored before the sandbox warning callback runs.
- A stale/reused PID file is reclaimed when no process holds the lock.
- A live second instance is blocked while the first process holds the lock.
- Killing the lock-holder process releases the kernel lock and allows the next launch to recover without deleting the lock file manually.

Latest focused instance-lock tests: `3 passed`.

GitHub Actions for the current fork head are awaiting maintainer approval (`action_required`); no workflow jobs have started yet.

Fixes #2033